### PR TITLE
simplify generate function in bulkload example

### DIFF
--- a/online-bulk-load/src/main/scala/org/tikv/bulkload/example/BulkLoadExample.scala
+++ b/online-bulk-load/src/main/scala/org/tikv/bulkload/example/BulkLoadExample.scala
@@ -60,6 +60,6 @@ object BulkLoadExample {
 
   private def genKey(i: Long): String = f"$i%012d"
 
-  private def genValue(valueLength: Int): String = Vector.fill(valueLength)('A').mkString("")
+  private def genValue(valueLength: Int): String = "A" * valueLength
 
 }


### PR DESCRIPTION
This closes #11 as duplicated.