### PR TITLE
use binary search to find partition

### DIFF
--- a/online-bulk-load/src/main/scala/org/tikv/bulkload/PartitionNotFound.scala
+++ b/online-bulk-load/src/main/scala/org/tikv/bulkload/PartitionNotFound.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 TiKV Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tikv.bulkload
+
+class PartitionNotFound(msg: String) extends Exception(msg) {
+
+}

--- a/online-bulk-load/src/main/scala/org/tikv/bulkload/example/BulkLoadExample.scala
+++ b/online-bulk-load/src/main/scala/org/tikv/bulkload/example/BulkLoadExample.scala
@@ -18,6 +18,7 @@ package org.tikv.bulkload.example
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.storage.StorageLevel
 import org.slf4j.LoggerFactory
 import org.tikv.bulkload.RawKVBulkLoader
 
@@ -76,7 +77,8 @@ object BulkLoadExample {
     val rdd = spark.sparkContext.parallelize(1L to size, partition).map { i =>
       val key = s"$prefix${genKey(i)}"
       (key.toArray.map(_.toByte), value.toArray.map(_.toByte))
-    }
+    }.persist(StorageLevel.DISK_ONLY)
+
     new RawKVBulkLoader(pdaddr).bulkLoad(rdd)
 
     val end = System.currentTimeMillis()


### PR DESCRIPTION
Signed-off-by: marsishandsome <marsishandsome@gmail.com>

use binary search to find partition

before: shuffle cost 8.4min
![image](https://user-images.githubusercontent.com/5574887/132606090-1062868d-8375-4e21-a4d4-356abb66051f.png)


after: shuffle cost 20s
![image](https://user-images.githubusercontent.com/5574887/132627880-2fb843b7-13c0-4a5d-b285-7eed9234f8f5.png)
