### PR TITLE
remove duplicate key after sorting

### DIFF
--- a/online-bulk-load/src/test/scala/org/tikv/bulkload/RawKVBulkLoaderSuite.scala
+++ b/online-bulk-load/src/test/scala/org/tikv/bulkload/RawKVBulkLoaderSuite.scala
@@ -31,7 +31,7 @@ class RawKVBulkLoaderSuite extends FunSuiteLike {
   val partitionSize = 10
 
 
-  test("insert and update") {
+  test("insert and update with duplicate key") {
     val keyPrefix = "k_"
 
     val sparkConf = new SparkConf()
@@ -43,8 +43,9 @@ class RawKVBulkLoaderSuite extends FunSuiteLike {
     val rawKVBulkLoader = new RawKVBulkLoader(tiConf, sparkConf)
 
     // insert
-    val rdd = spark.sparkContext.parallelize(startKey to endKey, partitionSize).map { i =>
-      (s"$keyPrefix$i".toArray.map(_.toByte), s"v1_$i".toArray.map(_.toByte))
+    val rdd = spark.sparkContext.parallelize(startKey to endKey, partitionSize).flatMap { i =>
+      val item = (s"$keyPrefix$i".toArray.map(_.toByte), s"v1_$i".toArray.map(_.toByte))
+      item :: item :: Nil
     }
     rawKVBulkLoader.bulkLoad(rdd)
 


### PR DESCRIPTION
Signed-off-by: marsishandsome <marsishandsome@gmail.com>

###  1. remove duplicate key
close https://github.com/tikv/migration/issues/30

client-java support deduplicate key in this PR https://github.com/tikv/client-java/pull/276

### 2. catch exception when calling `splitRegionAndScatter`