### PR TITLE
Replace the deprecated health API

### DIFF
--- a/cdc/tests/integration_tests/_utils/start_tidb_cluster_impl
+++ b/cdc/tests/integration_tests/_utils/start_tidb_cluster_impl
@@ -125,7 +125,7 @@ for idx in $(seq 1 $pd_count); do
 	done
 
 	i=0
-	while [ -z "$(curl http://${!host}:${!port}/pd/health 2>/dev/null | grep 'health' | grep 'true')" ]; do
+	while [ -z "$(curl http://${!host}:${!port}/pd/api/v1/health 2>/dev/null | grep 'health' | grep 'true')" ]; do
 		i=$((i + 1))
 		if [ "$i" -gt 60 ]; then
 			echo 'Failed to start upstream PD'
@@ -148,7 +148,7 @@ while ! curl -o /dev/null -sf http://${DOWN_PD_HOST}:${DOWN_PD_PORT}/pd/api/v1/v
 done
 
 i=0
-while [ -z "$(curl http://${DOWN_PD_HOST}:${DOWN_PD_PORT}/pd/health 2>/dev/null | grep 'health' | grep 'true')" ]; do
+while [ -z "$(curl http://${DOWN_PD_HOST}:${DOWN_PD_PORT}/pd/api/v1/health 2>/dev/null | grep 'health' | grep 'true')" ]; do
 	i=$((i + 1))
 	if [ "$i" -gt 60 ]; then
 		echo 'Failed to start downstream PD'

--- a/cdc/tests/integration_tests/_utils/start_tls_tidb_cluster_impl
+++ b/cdc/tests/integration_tests/_utils/start_tls_tidb_cluster_impl
@@ -64,7 +64,7 @@ done
 while [ -z "$(curl --cacert $TLS_DIR/ca.pem \
 	--cert $TLS_DIR/client.pem \
 	--key $TLS_DIR/client-key.pem \
-	https://${TLS_PD_HOST}:${TLS_PD_PORT}/pd/health 2>/dev/null | grep 'health' | grep 'true')" ]; do
+	https://${TLS_PD_HOST}:${TLS_PD_PORT}/pd/api/v1/health 2>/dev/null | grep 'health' | grep 'true')" ]; do
 	sleep 1
 done
 


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: Ref tikv/pd#4679

### What is changed and how does it work?

`/pd/health` has been deprecated for a long time. Use `/pd/api/v1/health` instead.

### Code changes

- No code

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Integration test
