### PR TITLE
[to #67] clean Makefile

### DIFF
--- a/.github/workflows/ci-br.yml
+++ b/.github/workflows/ci-br.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           cd br
           make check
-  br-ut:
+  br-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-br.yml
+++ b/.github/workflows/ci-br.yml
@@ -11,6 +11,18 @@ permissions:
   contents: read
 
 jobs:
+  br-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16.1'
+      - name: make check
+        shell: bash
+        run: |
+          cd br
+          make check
   br-ut:
     runs-on: ubuntu-latest
     steps:
@@ -18,36 +30,8 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.16.1'
-      - name: ut
+      - name: make test
         shell: bash
         run: |
           cd br
-          make unit_test_in_verify_ci
-  br-golangci-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.16.1'
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.42.0
-          working-directory: br
-          args: -v $(go list ./...| grep "github.com\/tikv\/migration\/br" | sed 's|github.com/tikv/migration/br/||') --config ../.golangci.yml --allow-parallel-runners --timeout=10m
-  br-gosec:
-    runs-on: ubuntu-latest
-    env:
-      GO111MODULE: on
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.16.1'
-      - name: gosec
-        shell: bash
-        run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@v2.9.1
-          cd br
-          gosec -fmt=junit-xml -out=results.xml -stdout -verbose=text -exclude=G103,G104,G204,G304,G307,G401,G404,G501,G505,G601 ./...
+          make test

--- a/.github/workflows/ci-br.yml
+++ b/.github/workflows/ci-br.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  br-check/tidy:
+  br-check-tidy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
         run: |
           cd br
           make check/tidy
-  br-check/golangci-lint:
+  br-check-golangci-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
         run: |
           cd br
           make check/golangci-lint
-  br-check/gosec:
+  br-check-gosec:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-br.yml
+++ b/.github/workflows/ci-br.yml
@@ -11,18 +11,42 @@ permissions:
   contents: read
 
 jobs:
-  br-check:
+  br-check/tidy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
           go-version: '1.16.1'
-      - name: make check
+      - name: make check/tidy
         shell: bash
         run: |
           cd br
-          make check
+          make check/tidy
+  br-check/golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16.1'
+      - name: make check/golangci-lint
+        shell: bash
+        run: |
+          cd br
+          make check/golangci-lint
+  br-check/gosec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16.1'
+      - name: make check/gosec
+        shell: bash
+        run: |
+          cd br
+          make check/gosec
   br-test:
     runs-on: ubuntu-latest
     steps:

--- a/br/Makefile
+++ b/br/Makefile
@@ -22,7 +22,7 @@ PACKAGES    := go list ./...
 DIRECTORIES := $(PACKAGES) | sed 's|github.com/tikv/migration/br/||'
 
 # test 
-TEST_COVERAGE_DIR := .
+COVERAGE_DIR := build
 TEST_PARALLEL = 8
 
 LDFLAGS += -X "github.com/tikv/migration/br/pkg/version/build.ReleaseVersion=$(shell git describe --tags --dirty --always)"
@@ -31,9 +31,9 @@ LDFLAGS += -X "github.com/tikv/migration/br/pkg/version/build.GitHash=$(shell gi
 LDFLAGS += -X "github.com/tikv/migration/br/pkg/version/build.GitBranch=$(shell git rev-parse --abbrev-ref HEAD)"
 
 check: 
-	@make check/tidy
-	@make check/golangci-lint
-	@make check/gosec
+	make check/tidy
+	make check/golangci-lint
+	make check/gosec
 
 check/tidy:
 	cp go.sum /tmp/go.sum.origin
@@ -49,32 +49,32 @@ check/gosec:
 	gosec -fmt=junit-xml -out=results.xml -stdout -verbose=text -exclude=G103,G104,G204,G304,G307,G401,G404,G501,G505,G601 ./...
 
 test: build/gocov build/gocov-xml
-	@make failpoint/enable
-	@export TZ='Asia/Shanghai';
-	$(GO) test -p $(TEST_PARALLEL) -race -ldflags '$(LDFLAGS)' -tags leak $$($(PACKAGES)) -coverprofile="$(TEST_COVERAGE_DIR)/br_cov.unit_test.plain" || ( make failpoint/disable && exit 1 )
-	tools/bin/gocov convert "$(TEST_COVERAGE_DIR)/br_cov.unit_test.plain" | tools/bin/gocov-xml > "$(TEST_COVERAGE_DIR)/br_cov.unit_test.out"
-	@make failpoint/disable
+	make failpoint/enable
+	export TZ='Asia/Shanghai';
+	mkdir -p $(COVERAGE_DIR)
+	$(GO) test -p $(TEST_PARALLEL) -race -ldflags '$(LDFLAGS)' -tags leak $$($(PACKAGES)) -coverprofile=$(COVERAGE_DIR)/coverage.raw || ( make failpoint/disable && exit 1 )
+	tools/bin/gocov convert $(COVERAGE_DIR)/coverage.raw | tools/bin/gocov-xml > $(COVERAGE_DIR)/coverage.xml
+	make failpoint/disable
 
 failpoint/enable: build/failpoint-ctl
-	find `pwd`/ -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl enable
+	find `pwd` -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl enable
 
 failpoint/disable: build/failpoint-ctl
-	find `pwd`/ -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl disable
+	find `pwd` -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl disable
 
 build:
 	CGO_ENABLED=1 $(GO) build -tags codes -ldflags '$(LDFLAGS)' -o bin/br cmd/br/*.go
 
-build/gocov: tools/check/go.mod
+build/gocov: 
 	cd tools/check && $(GO) build -mod=mod -o ../bin/gocov github.com/axw/gocov/gocov
 
-build/gocov-xml: tools/check/go.mod
+build/gocov-xml: 
 	cd tools/check && $(GO) build -mod=mod -o ../bin/gocov-xml github.com/AlekSi/gocov-xml
 
-build/failpoint-ctl: tools/check/go.mod
+build/failpoint-ctl:
 	cd tools/check && $(GO) build -o ../bin/failpoint-ctl github.com/pingcap/failpoint/failpoint-ctl
 
 clean:
 	go clean -i ./...
-	rm -rf *.out
-	rm -rf bin
-	rm -rf tools/bin
+	rm -rf *.out bin tools/bin
+	rm -rf $(COVERAGE_DIR)/coverage.raw $(COVERAGE_DIR)/coverage.xml

--- a/br/Makefile
+++ b/br/Makefile
@@ -40,15 +40,14 @@ check/tidy:
 	$(GO) mod tidy
 	diff -q go.sum /tmp/go.sum.origin
 
-check/golangci-lint: 
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./tools/bin v1.41.1
+check/golangci-lint: tools/bin/golangci-lint
 	GO111MODULE=on CGO_ENABLED=0 tools/bin/golangci-lint run -v $$($(DIRECTORIES)) --config ../.golangci.yml --timeout 5m
 
 check/gosec:
 	$(GO) install github.com/securego/gosec/v2/cmd/gosec@v2.9.1
 	gosec -fmt=junit-xml -out=results.xml -stdout -verbose=text -exclude=G103,G104,G204,G304,G307,G401,G404,G501,G505,G601 ./...
 
-test: build/gocov build/gocov-xml
+test: tools/bin/gocov tools/bin/gocov-xml
 	make failpoint/enable
 	export TZ='Asia/Shanghai';
 	mkdir -p $(COVERAGE_DIR)
@@ -56,25 +55,29 @@ test: build/gocov build/gocov-xml
 	tools/bin/gocov convert $(COVERAGE_DIR)/coverage.raw | tools/bin/gocov-xml > $(COVERAGE_DIR)/coverage.xml
 	make failpoint/disable
 
-failpoint/enable: build/failpoint-ctl
+failpoint/enable: tools/bin/failpoint-ctl
 	find `pwd` -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl enable
 
-failpoint/disable: build/failpoint-ctl
+failpoint/disable: tools/bin/failpoint-ctl
 	find `pwd` -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl disable
+
+tools/bin/golangci-lint:
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./tools/bin v1.41.1
+
+tools/bin/gocov: tools/check/go.mod
+	cd tools/check && $(GO) build -mod=mod -o ../bin/gocov github.com/axw/gocov/gocov
+
+tools/bin/gocov-xml: tools/check/go.mod
+	cd tools/check && $(GO) build -mod=mod -o ../bin/gocov-xml github.com/AlekSi/gocov-xml
+
+tools/bin/failpoint-ctl: tools/check/go.mod
+	cd tools/check && $(GO) build -o ../bin/failpoint-ctl github.com/pingcap/failpoint/failpoint-ctl
 
 build:
 	CGO_ENABLED=1 $(GO) build -tags codes -ldflags '$(LDFLAGS)' -o bin/br cmd/br/*.go
 
-build/gocov: 
-	cd tools/check && $(GO) build -mod=mod -o ../bin/gocov github.com/axw/gocov/gocov
-
-build/gocov-xml: 
-	cd tools/check && $(GO) build -mod=mod -o ../bin/gocov-xml github.com/AlekSi/gocov-xml
-
-build/failpoint-ctl:
-	cd tools/check && $(GO) build -o ../bin/failpoint-ctl github.com/pingcap/failpoint/failpoint-ctl
-
 clean:
 	go clean -i ./...
 	rm -rf *.out bin tools/bin
-	rm -rf $(COVERAGE_DIR)/coverage.raw $(COVERAGE_DIR)/coverage.xml
+	rm -rf results.xml 
+	rm -rf br-junit-report.xml $(COVERAGE_DIR)/coverage.raw $(COVERAGE_DIR)/coverage.xml

--- a/br/Makefile
+++ b/br/Makefile
@@ -30,14 +30,25 @@ LDFLAGS += -X "github.com/tikv/migration/br/pkg/version/build.BuildTS=$(shell da
 LDFLAGS += -X "github.com/tikv/migration/br/pkg/version/build.GitHash=$(shell git rev-parse HEAD)"
 LDFLAGS += -X "github.com/tikv/migration/br/pkg/version/build.GitBranch=$(shell git rev-parse --abbrev-ref HEAD)"
 
-check: build/golangci-lint
+check: 
+	@make check/tidy
+	@make check/golangci-lint
+	@make check/gosec
+
+check/tidy:
+	cp go.sum /tmp/go.sum.origin
 	$(GO) mod tidy
+	diff -q go.sum /tmp/go.sum.origin
+
+check/golangci-lint: 
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./tools/bin v1.41.1
 	GO111MODULE=on CGO_ENABLED=0 tools/bin/golangci-lint run -v $$($(DIRECTORIES)) --config ../.golangci.yml --timeout 5m
+
+check/gosec:
 	$(GO) install github.com/securego/gosec/v2/cmd/gosec@v2.9.1
 	gosec -fmt=junit-xml -out=results.xml -stdout -verbose=text -exclude=G103,G104,G204,G304,G307,G401,G404,G501,G505,G601 ./...
 
 test: build/gocov build/gocov-xml
-	$(GO) mod tidy
 	@make failpoint/enable
 	@export TZ='Asia/Shanghai';
 	$(GO) test -p $(TEST_PARALLEL) -race -ldflags '$(LDFLAGS)' -tags leak $$($(PACKAGES)) -coverprofile="$(TEST_COVERAGE_DIR)/br_cov.unit_test.plain" || ( make failpoint/disable && exit 1 )
@@ -51,11 +62,7 @@ failpoint/disable: build/failpoint-ctl
 	find `pwd`/ -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl disable
 
 build:
-	$(GO) mod tidy
 	CGO_ENABLED=1 $(GO) build -tags codes -ldflags '$(LDFLAGS)' -o bin/br cmd/br/*.go
-
-build/golangci-lint:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./tools/bin v1.41.1
 
 build/gocov: tools/check/go.mod
 	cd tools/check && $(GO) build -mod=mod -o ../bin/gocov github.com/axw/gocov/gocov

--- a/br/Makefile
+++ b/br/Makefile
@@ -12,111 +12,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PROJECT=br
-GOPATH ?= $(shell go env GOPATH)
-P=8
+.PHONY: check test build clean 
+default: build
+all: check test build clean
 
-# Ensure GOPATH is set before running build process.
-ifeq "$(GOPATH)" ""
-  $(error Please set the environment variable GOPATH before running `make`)
-endif
-FAIL_ON_STDOUT := awk '{ print } END { if (NR > 0) { exit 1 } }'
+# golang
+GO          := GO111MODULE=on go
+PACKAGES    := go list ./...
+DIRECTORIES := $(PACKAGES) | sed 's|github.com/tikv/migration/br/||'
 
-CURDIR := $(shell pwd)
-path_to_add := $(addsuffix /bin,$(subst :,/bin:,$(GOPATH))):$(PWD)/tools/bin
-export PATH := $(path_to_add):$(PATH)
-
-GO              := GO111MODULE=on go
-GOBUILD         := $(GO) build $(BUILD_FLAG) -tags codes
-GOTEST          := $(GO) test -p $(P)
-OVERALLS        := GO111MODULE=on overalls
-STATICCHECK     := GO111MODULE=on staticcheck
-
-LINUX     := "Linux"
-MAC       := "Darwin"
-
-FAILPOINT_ENABLE  := find $$PWD/ -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl enable
-FAILPOINT_DISABLE := find $$PWD/ -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl disable
-
-TARGET = ""
-
-RACE_FLAG =
-ifeq ("$(WITH_RACE)", "1")
-	RACE_FLAG = -race
-	GOBUILD   = GOPATH=$(GOPATH) $(GO) build
-endif
-
-CHECK_FLAG =
-ifeq ("$(WITH_CHECK)", "1")
-	CHECK_FLAG = $(TEST_LDFLAGS)
-endif
-
-BR_PKG := github.com/tikv/migration/br
-BR_PACKAGES       := go list ./...| grep "github.com\/tikv\/migration\/br"
-BR_PACKAGE_DIRECTORIES := $(BR_PACKAGES) | sed 's|github.com/tikv/migration/br/||'
-BR_BIN            := bin/br
-TEST_DIR          := /tmp/backup_restore_test
-
-TEST_COVERAGE_DIR := "."
-
-.PHONY: build_br clean unit_test check check-static
-
-default: build_br
-
-failpoint-enable: tools/bin/failpoint-ctl
-# Converting gofail failpoints...
-	@$(FAILPOINT_ENABLE)
-
-failpoint-disable: tools/bin/failpoint-ctl
-# Restoring gofail failpoints...
-	@$(FAILPOINT_DISABLE)
-
-tools/bin/failpoint-ctl: tools/check/go.mod
-	cd tools/check; \
-	$(GO) build -o ../bin/failpoint-ctl github.com/pingcap/failpoint/failpoint-ctl
+# test 
+TEST_COVERAGE_DIR := .
+TEST_PARALLEL = 8
 
 LDFLAGS += -X "github.com/tikv/migration/br/pkg/version/build.ReleaseVersion=$(shell git describe --tags --dirty --always)"
 LDFLAGS += -X "github.com/tikv/migration/br/pkg/version/build.BuildTS=$(shell date -u '+%Y-%m-%d %H:%M:%S')"
 LDFLAGS += -X "github.com/tikv/migration/br/pkg/version/build.GitHash=$(shell git rev-parse HEAD)"
 LDFLAGS += -X "github.com/tikv/migration/br/pkg/version/build.GitBranch=$(shell git rev-parse --abbrev-ref HEAD)"
 
-build_br:
-	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(BR_BIN) cmd/br/*.go
+check: build/golangci-lint
+	$(GO) mod tidy
+	GO111MODULE=on CGO_ENABLED=0 tools/bin/golangci-lint run -v $$($(DIRECTORIES)) --config ../.golangci.yml --timeout 5m
+	$(GO) install github.com/securego/gosec/v2/cmd/gosec@v2.9.1
+	gosec -fmt=junit-xml -out=results.xml -stdout -verbose=text -exclude=G103,G104,G204,G304,G307,G401,G404,G501,G505,G601 ./...
 
-test: unit_test
-
-unit_test: export ARGS=$$($(BR_PACKAGES))
-unit_test:
-	@make failpoint-enable
+test: build/gocov build/gocov-xml
+	$(GO) mod tidy
+	@make failpoint/enable
 	@export TZ='Asia/Shanghai';
-	$(GOTEST) $(RACE_FLAG) -ldflags '$(LDFLAGS)' -tags leak $(ARGS) -coverprofile=coverage.txt || ( make failpoint-disable && exit 1 )
-	@make failpoint-disable
-unit_test_in_verify_ci: export ARGS=$$($(BR_PACKAGES))
-unit_test_in_verify_ci: tools/bin/gotestsum tools/bin/gocov tools/bin/gocov-xml
-	@make failpoint-enable
-	@export TZ='Asia/Shanghai';
-	@mkdir -p $(TEST_COVERAGE_DIR)
-	CGO_ENABLED=1 tools/bin/gotestsum --junitfile "$(TEST_COVERAGE_DIR)/br-junit-report.xml" -- $(RACE_FLAG) -ldflags '$(LDFLAGS)' \
-	-tags leak $(ARGS) -coverprofile="$(TEST_COVERAGE_DIR)/br_cov.unit_test.plain" || ( make failpoint-disable && exit 1 )
+	$(GO) test -p $(TEST_PARALLEL) -race -ldflags '$(LDFLAGS)' -tags leak $$($(PACKAGES)) -coverprofile="$(TEST_COVERAGE_DIR)/br_cov.unit_test.plain" || ( make failpoint/disable && exit 1 )
 	tools/bin/gocov convert "$(TEST_COVERAGE_DIR)/br_cov.unit_test.plain" | tools/bin/gocov-xml > "$(TEST_COVERAGE_DIR)/br_cov.unit_test.out"
-	@make failpoint-disable
+	@make failpoint/disable
 
-check: check-static
+failpoint/enable: build/failpoint-ctl
+	find `pwd`/ -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl enable
 
-check-static: tools/bin/golangci-lint
-	GO111MODULE=on CGO_ENABLED=0 tools/bin/golangci-lint run -v $$($(BR_PACKAGE_DIRECTORIES)) --config ../.golangci.yml --timeout 5m
+failpoint/disable: build/failpoint-ctl
+	find `pwd`/ -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl disable
 
-tools/bin/golangci-lint:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ./tools/bin v1.41.1
+build:
+	$(GO) mod tidy
+	CGO_ENABLED=1 $(GO) build -tags codes -ldflags '$(LDFLAGS)' -o bin/br cmd/br/*.go
 
-tools/bin/gotestsum: tools/check/go.mod
-	cd tools/check && $(GO) build -o ../bin/gotestsum gotest.tools/gotestsum
+build/golangci-lint:
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./tools/bin v1.41.1
 
-tools/bin/gocov: tools/check/go.mod
-	cd tools/check && $(GO) build -mod=mod -o ../bin/gocov  github.com/axw/gocov/gocov
+build/gocov: tools/check/go.mod
+	cd tools/check && $(GO) build -mod=mod -o ../bin/gocov github.com/axw/gocov/gocov
 
-tools/bin/gocov-xml: tools/check/go.mod
+build/gocov-xml: tools/check/go.mod
 	cd tools/check && $(GO) build -mod=mod -o ../bin/gocov-xml github.com/AlekSi/gocov-xml
+
+build/failpoint-ctl: tools/check/go.mod
+	cd tools/check && $(GO) build -o ../bin/failpoint-ctl github.com/pingcap/failpoint/failpoint-ctl
 
 clean:
 	go clean -i ./...

--- a/br/Makefile
+++ b/br/Makefile
@@ -30,10 +30,7 @@ LDFLAGS += -X "github.com/tikv/migration/br/pkg/version/build.BuildTS=$(shell da
 LDFLAGS += -X "github.com/tikv/migration/br/pkg/version/build.GitHash=$(shell git rev-parse HEAD)"
 LDFLAGS += -X "github.com/tikv/migration/br/pkg/version/build.GitBranch=$(shell git rev-parse --abbrev-ref HEAD)"
 
-check: 
-	make check/tidy
-	make check/golangci-lint
-	make check/gosec
+check: check/tidy check/golangci-lint check/gosec
 
 check/tidy:
 	cp go.sum /tmp/go.sum.origin


### PR DESCRIPTION
Signed-off-by: Jian Zhang <zjsariel@gmail.com>

<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: [to #67]

Problem Description: the current Makefile is hard to understand and maintain

### What is changed and how does it work?

this pr reformatted the Makefile to make it readable to reduce the maintenance burden in the following methods:

- targets to build binaries are in a common namespace `build`, for example, `build/golangci-lint`, `build/gocov`, `build/failpoint-ctl`, etc.
- removed the `unit_test_in_verify_ci` build target since it's duplicated with the `test` target

this pr also altered the github actions for CI to utilize Makefile so that the build target in the Makefile itself is tested by github actions as well

### Code changes

<!-- REMOVE the items that are not applicable -->
- No code

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test
- Integration test

### Side effects

<!-- REMOVE the items that are not applicable -->
- No side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- No related changes
