### PR TITLE
[fix #104]clean br command args

### DIFF
--- a/br/cmd/br/backup.go
+++ b/br/cmd/br/backup.go
@@ -66,7 +66,7 @@ func newRawBackupCommand() *cobra.Command {
 	// TODO: remove experimental tag if it's stable
 	command := &cobra.Command{
 		Use:   "raw",
-		Short: "(experimental) backup a raw kv range from TiKV cluster",
+		Short: "backup full raw kv pairs from TiKV cluster",
 		Args:  cobra.NoArgs,
 		RunE: func(command *cobra.Command, _ []string) error {
 			return runBackupRawCommand(command, "Raw backup")

--- a/br/cmd/br/cmd.go
+++ b/br/cmd/br/cmd.go
@@ -78,6 +78,9 @@ func AddFlags(cmd *cobra.Command) {
 		"Set the slow log file path. If not set, discard slow logs")
 	_ = cmd.PersistentFlags().MarkHidden(FlagSlowLogFile)
 	_ = cmd.PersistentFlags().MarkHidden(FlagRedactLog)
+	_ = cmd.PersistentFlags().MarkHidden(FlagRedactInfoLog)
+	_ = cmd.PersistentFlags().MarkHidden(FlagLogFormat)
+	_ = cmd.PersistentFlags().MarkHidden(FlagStatusAddr)
 }
 
 // Init initializes BR cli.

--- a/br/cmd/br/main.go
+++ b/br/cmd/br/main.go
@@ -37,8 +37,8 @@ func main() {
 	}()
 
 	rootCmd := &cobra.Command{
-		Use:              "br",
-		Short:            "br is a TiDB/TiKV cluster backup restore tool.",
+		Use:              "tikv-br",
+		Short:            "tikv-br is a TiKV cluster backup restore tool.",
 		TraverseChildren: true,
 		SilenceUsage:     true,
 	}

--- a/br/cmd/br/restore.go
+++ b/br/cmd/br/restore.go
@@ -42,7 +42,7 @@ func runRestoreRawCommand(command *cobra.Command, cmdName string) error {
 func NewRestoreCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:          "restore",
-		Short:        "restore a TiDB/TiKV cluster",
+		Short:        "restore a TiKV cluster",
 		SilenceUsage: true,
 		PersistentPreRunE: func(c *cobra.Command, args []string) error {
 			if err := Init(c); err != nil {
@@ -66,7 +66,7 @@ func NewRestoreCommand() *cobra.Command {
 func newRawRestoreCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "raw",
-		Short: "(experimental) restore a raw kv range to TiKV cluster",
+		Short: "restore raw kv sst files to TiKV cluster",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runRestoreRawCommand(cmd, "Raw restore")

--- a/br/pkg/storage/azblob.go
+++ b/br/pkg/storage/azblob.go
@@ -50,6 +50,10 @@ func defineAzblobFlags(flags *pflag.FlagSet) {
 	flags.String(azblobAccessTierOption, "", "Specify the storage class for azblob")
 	flags.String(azblobAccountName, "", "Specify the account name for azblob")
 	flags.String(azblobAccountKey, "", "Specify the account key for azblob")
+	_ = flags.MarkHidden(azblobEndpointOption)
+	_ = flags.MarkHidden(azblobAccessTierOption)
+	_ = flags.MarkHidden(azblobAccountName)
+	_ = flags.MarkHidden(azblobAccountKey)
 }
 
 func (options *AzblobBackendOptions) parseFromFlags(flags *pflag.FlagSet) error {

--- a/br/pkg/storage/gcs.go
+++ b/br/pkg/storage/gcs.go
@@ -57,6 +57,10 @@ func defineGCSFlags(flags *pflag.FlagSet) {
 	flags.String(gcsStorageClassOption, "", "(experimental) Specify the GCS storage class for objects")
 	flags.String(gcsPredefinedACL, "", "(experimental) Specify the GCS predefined acl for objects")
 	flags.String(gcsCredentialsFile, "", "(experimental) Set the GCS credentials file path")
+	_ = flags.MarkHidden(gcsEndpointOption)
+	_ = flags.MarkHidden(gcsStorageClassOption)
+	_ = flags.MarkHidden(gcsPredefinedACL)
+	_ = flags.MarkHidden(gcsCredentialsFile)
 }
 
 func (options *GCSBackendOptions) parseFromFlags(flags *pflag.FlagSet) error {

--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -180,6 +180,13 @@ func defineS3Flags(flags *pflag.FlagSet) {
 		"Leave empty to use S3 owned key.")
 	flags.String(s3ACLOption, "", "(experimental) Set the S3 canned ACLs, e.g. authenticated-read")
 	flags.String(s3ProviderOption, "", "(experimental) Set the S3 provider, e.g. aws, alibaba, ceph")
+	_ = flags.MarkHidden(s3EndpointOption)
+	_ = flags.MarkHidden(s3RegionOption)
+	_ = flags.MarkHidden(s3StorageClassOption)
+	_ = flags.MarkHidden(s3SseOption)
+	_ = flags.MarkHidden(s3SseKmsKeyIDOption)
+	_ = flags.MarkHidden(s3ACLOption)
+	_ = flags.MarkHidden(s3ProviderOption)
 }
 
 // parseFromFlags parse S3BackendOptions from command line flags.

--- a/br/pkg/task/backup.go
+++ b/br/pkg/task/backup.go
@@ -46,6 +46,7 @@ func DefineBackupFlags(flags *pflag.FlagSet) {
 	flags.Bool(flagRemoveSchedulers, false,
 		"disable the balance, shuffle and region-merge schedulers in PD to speed up backup")
 	// This flag can impact the online cluster, so hide it in case of abuse.
+	_ = flags.MarkHidden(flagCompressionType)
 	_ = flags.MarkHidden(flagRemoveSchedulers)
 	_ = flags.MarkHidden(flagBackupTimeago)
 	_ = flags.MarkHidden(flagLastBackupTS)

--- a/br/pkg/task/backup.go
+++ b/br/pkg/task/backup.go
@@ -47,6 +47,10 @@ func DefineBackupFlags(flags *pflag.FlagSet) {
 		"disable the balance, shuffle and region-merge schedulers in PD to speed up backup")
 	// This flag can impact the online cluster, so hide it in case of abuse.
 	_ = flags.MarkHidden(flagRemoveSchedulers)
+	_ = flags.MarkHidden(flagBackupTimeago)
+	_ = flags.MarkHidden(flagLastBackupTS)
+	_ = flags.MarkHidden(flagBackupTS)
+	_ = flags.MarkHidden(flagGCTTL)
 
 	// Disable stats by default. because of
 	// 1. DumpStatsToJson is not stable

--- a/br/pkg/task/backup_raw.go
+++ b/br/pkg/task/backup_raw.go
@@ -49,8 +49,7 @@ func DefineRawBackupFlags(command *cobra.Command) {
 		"disable the balance, shuffle and region-merge schedulers in PD to speed up backup.")
 
 	// This flag can impact the online cluster, so hide it in case of abuse.
-	_ = command.Flags().MarkHidden(flagRemoveSchedulers)
-
+	_ = command.Flags().MarkHidden(flagCompressionType)
 	_ = command.Flags().MarkHidden(flagRemoveSchedulers)
 	_ = command.Flags().MarkHidden(flagStartKey)
 	_ = command.Flags().MarkHidden(flagEndKey)

--- a/br/pkg/task/backup_raw.go
+++ b/br/pkg/task/backup_raw.go
@@ -40,7 +40,7 @@ func DefineRawBackupFlags(command *cobra.Command) {
 		"The format of start and end key. Available options: \"raw\", \"escaped\", \"hex\".")
 
 	command.Flags().StringP(flagDstAPIVersion, "", "",
-		"The encoding method of backuped SST files for destination TiKV cluster, default to the source TiKV cluster. Available options: \"v1\", \"v1ttl\", \"v2\".")
+		`The encoding method of backuped SST files for destination TiKV cluster. Available options: "v1", "v1ttl", "v2".`)
 
 	command.Flags().String(flagCompressionType, "zstd",
 		"The compression algorithm of the backuped SST files. Available options: \"lz4\", \"zstd\", \"snappy\".")
@@ -50,6 +50,11 @@ func DefineRawBackupFlags(command *cobra.Command) {
 
 	// This flag can impact the online cluster, so hide it in case of abuse.
 	_ = command.Flags().MarkHidden(flagRemoveSchedulers)
+
+	_ = command.Flags().MarkHidden(flagRemoveSchedulers)
+	_ = command.Flags().MarkHidden(flagStartKey)
+	_ = command.Flags().MarkHidden(flagEndKey)
+	_ = command.Flags().MarkHidden(flagKeyFormat)
 }
 
 // RunBackupRaw starts a backup task inside the current goroutine.

--- a/br/pkg/task/common.go
+++ b/br/pkg/task/common.go
@@ -82,19 +82,25 @@ const (
 // DefineCommonFlags defines the flags common to all BRIE commands.
 func DefineCommonFlags(flags *pflag.FlagSet) {
 	flags.BoolP(flagSendCreds, "c", true, "Whether send credentials to tikv")
-	flags.StringP(flagStorage, "s", "", `specify the url where backup storage, eg, "s3://bucket/path/prefix"`)
+	flags.StringP(flagStorage, "s", "", `specify the path where backup storage, eg, "local:///home/backup_data"`)
 	flags.StringSliceP(flagPD, "u", []string{"127.0.0.1:2379"}, "PD address")
 	flags.String(flagCA, "", "CA certificate path for TLS connection")
 	flags.String(flagCert, "", "Certificate path for TLS connection")
 	flags.String(flagKey, "", "Private key path for TLS connection")
 	flags.Uint(flagChecksumConcurrency, variable.DefChecksumTableConcurrency, "The concurrency of table checksumming")
+	_ = flags.MarkHidden(flagSendCreds)
+	_ = flags.MarkHidden(flagCA)
+	_ = flags.MarkHidden(flagCert)
+	_ = flags.MarkHidden(flagKey)
 	_ = flags.MarkHidden(flagChecksumConcurrency)
 
 	flags.Uint64(flagRateLimit, unlimited, "The rate limit of the task, MB/s per node")
+	_ = flags.MarkHidden(flagRateLimit)
 	flags.Bool(flagChecksum, true, "Run checksum at end of task")
 	flags.Bool(flagRemoveTiFlash, true,
 		"Remove TiFlash replicas before backup or restore, for unsupported versions of TiFlash")
-
+	_ = flags.MarkDeprecated(flagRemoveTiFlash,
+		"TiFlash is fully supported by BR now, removing TiFlash isn't needed any more. This flag would be ignored.")
 	// Default concurrency is different for backup and restore.
 	// Leave it 0 and let them adjust the value.
 	flags.Uint32(flagConcurrency, 0, "The size of thread pool on each node that executes the task")
@@ -103,12 +109,11 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 
 	flags.Uint64(flagRateLimitUnit, units.MiB, "The unit of rate limit")
 	_ = flags.MarkHidden(flagRateLimitUnit)
-	_ = flags.MarkDeprecated(flagRemoveTiFlash,
-		"TiFlash is fully supported by BR now, removing TiFlash isn't needed any more. This flag would be ignored.")
 
 	flags.Bool(flagCheckRequirement, true,
 		"Whether start version check before execute command")
 	flags.Duration(flagSwitchModeInterval, defaultSwitchInterval, "maintain import mode on TiKV during restore")
+	_ = flags.MarkHidden(flagSwitchModeInterval)
 	flags.Duration(flagGrpcKeepaliveTime, defaultGRPCKeepaliveTime,
 		"the interval of pinging gRPC peer, must keep the same value with TiKV and PD")
 	flags.Duration(flagGrpcKeepaliveTimeout, defaultGRPCKeepaliveTimeout,
@@ -118,7 +123,7 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 
 	flags.Bool(flagEnableOpenTracing, false,
 		"Set whether to enable opentracing during the backup/restore process")
-
+	_ = flags.MarkHidden(flagEnableOpenTracing)
 	flags.BoolP(flagNoCreds, "", false, "Don't load credentials")
 	_ = flags.MarkHidden(flagNoCreds)
 	flags.BoolP(flagSkipCheckPath, "", false, "Skip path verification")
@@ -131,7 +136,9 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 		"aes-crypter key, used to encrypt/decrypt the data "+
 			"by the hexadecimal string, eg: \"0123456789abcdef0123456789abcdef\"")
 	flags.String(flagCipherKeyFile, "", "FilePath, its content is used as the cipher-key")
-
+	_ = flags.MarkHidden(flagCipherType)
+	_ = flags.MarkHidden(flagCipherKey)
+	_ = flags.MarkHidden(flagCipherKeyFile)
 	storage.DefineFlags(flags)
 }
 

--- a/br/pkg/task/common.go
+++ b/br/pkg/task/common.go
@@ -54,7 +54,6 @@ const (
 	flagRateLimitUnit       = "ratelimit-unit"
 	flagConcurrency         = "concurrency"
 	flagChecksum            = "checksum"
-	flagRemoveTiFlash       = "remove-tiflash"
 	flagCheckRequirement    = "check-requirements"
 	flagSwitchModeInterval  = "switch-mode-interval"
 	// flagGrpcKeepaliveTime is the interval of pinging the server.
@@ -97,10 +96,6 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 	flags.Uint64(flagRateLimit, unlimited, "The rate limit of the task, MB/s per node")
 	_ = flags.MarkHidden(flagRateLimit)
 	flags.Bool(flagChecksum, true, "Run checksum at end of task")
-	flags.Bool(flagRemoveTiFlash, true,
-		"Remove TiFlash replicas before backup or restore, for unsupported versions of TiFlash")
-	_ = flags.MarkDeprecated(flagRemoveTiFlash,
-		"TiFlash is fully supported by BR now, removing TiFlash isn't needed any more. This flag would be ignored.")
 	// Default concurrency is different for backup and restore.
 	// Leave it 0 and let them adjust the value.
 	flags.Uint32(flagConcurrency, 0, "The size of thread pool on each node that executes the task")

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -45,6 +45,7 @@ func DefineRestoreCommonFlags(flags *pflag.FlagSet) {
 		"concurrency pd-relative operations like split & scatter.")
 	flags.Duration(FlagBatchFlushInterval, defaultBatchFlushInterval,
 		"after how long a restore batch would be auto sended.")
+	_ = flags.MarkHidden(flagOnline)
 	_ = flags.MarkHidden(FlagMergeRegionSizeBytes)
 	_ = flags.MarkHidden(FlagMergeRegionKeyCount)
 	_ = flags.MarkHidden(FlagPDConcurrency)

--- a/br/pkg/task/restore_raw.go
+++ b/br/pkg/task/restore_raw.go
@@ -21,7 +21,9 @@ func DefineRawRestoreFlags(command *cobra.Command) {
 	command.Flags().StringP(flagKeyFormat, "", "hex", "start/end key format, support raw|escaped|hex")
 	command.Flags().StringP(flagStartKey, "", "", "restore raw kv start key, key is inclusive")
 	command.Flags().StringP(flagEndKey, "", "", "restore raw kv end key, key is exclusive")
-
+	_ = command.Flags().MarkHidden(flagKeyFormat)
+	_ = command.Flags().MarkHidden(flagStartKey)
+	_ = command.Flags().MarkHidden(flagEndKey)
 	DefineRestoreCommonFlags(command.PersistentFlags())
 }
 


### PR DESCRIPTION
Signed-off-by: haojinming <jinming.hao@pingcap.com>

<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #104 
Problem Description: 
 clean command args as descriped in https://pingcap.feishu.cn/docs/doccnCay8PSAR5uiw6RhlXEVz7b.
### What is changed and how does it work?


### Code changes

<!-- REMOVE the items that are not applicable -->
- Has exported function/method change

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test
- Manual test (add detailed scripts or steps below)
-
### Side effects

<!-- REMOVE the items that are not applicable -->
- No side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- No related changes
