### PR TITLE
[close #108] Br debug checksum cmd

### DIFF
--- a/br/cmd/br/debug.go
+++ b/br/cmd/br/debug.go
@@ -4,17 +4,25 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"path"
 	"reflect"
+	"strings"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/log"
 	"github.com/spf13/cobra"
+	"github.com/tikv/migration/br/pkg/backup"
+	"github.com/tikv/migration/br/pkg/checksum"
 	"github.com/tikv/migration/br/pkg/metautil"
+	"github.com/tikv/migration/br/pkg/pdutil"
 	"github.com/tikv/migration/br/pkg/task"
 	"github.com/tikv/migration/br/pkg/utils"
 	"github.com/tikv/migration/br/pkg/version/build"
+	pd "github.com/tikv/pd/client"
+	"go.uber.org/zap"
 )
 
 // NewDebugCommand return a debug subcommand.
@@ -51,10 +59,9 @@ func newCheckSumCommand() *cobra.Command {
 		Short: "check the backup data",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return errors.Errorf("checksum is unsupported")
+			return runRawChecksumCommand(cmd, "RawChecksum")
 		},
 	}
-	command.Hidden = true
 	return command
 }
 
@@ -77,6 +84,7 @@ func newBackupMetaValidateCommand() *cobra.Command {
 		},
 	}
 	command.Flags().Uint64("offset", 0, "the offset of table id alloctor")
+	command.Hidden = true
 	return command
 }
 
@@ -222,4 +230,56 @@ func setPDConfigCommand() *cobra.Command {
 		},
 	}
 	return pdConfigCmd
+}
+
+func runRawChecksumCommand(command *cobra.Command, cmdName string) error {
+	cfg := task.Config{LogProgress: HasLogFile()}
+	err := cfg.ParseFromFlags(command.Flags())
+	if err != nil {
+		command.SilenceUsage = false
+		return errors.Trace(err)
+	}
+
+	ctx := GetDefaultContext()
+	pdAddress := strings.Join(cfg.PD, ",")
+	securityOption := pd.SecurityOption{}
+	var tlsConf *tls.Config = nil
+	if cfg.TLS.IsEnabled() {
+		securityOption.CAPath = cfg.TLS.CA
+		securityOption.CertPath = cfg.TLS.Cert
+		securityOption.KeyPath = cfg.TLS.Key
+		tlsConf, err = cfg.TLS.ToTLSConfig()
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	pdCtrl, err := pdutil.NewPdController(ctx, pdAddress, tlsConf, securityOption)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	storageApiVersion, err := backup.GetCurrentTiKVApiVersion(ctx, pdCtrl.GetPDClient(), tlsConf)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	backupMeta, fileChecksum, keyRanges, err := task.CalcChecksumFromBackupMeta(ctx, storageApiVersion, &cfg)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if storageApiVersion != backupMeta.ApiVersion && backupMeta.ApiVersion != kvrpcpb.APIVersion_V2 {
+		log.Error("Unsupported storage version", zap.String("storage", storageApiVersion.String()),
+			zap.String("backupMeta", backupMeta.ApiVersion.String()))
+		return errors.New("unsupported storage version")
+	}
+	checksumMethod := checksum.StorageChecksumCommand
+	if storageApiVersion != backupMeta.ApiVersion {
+		checksumMethod = checksum.StorageScanCommand
+	}
+
+	executor := checksum.NewExecutor(keyRanges, cfg.PD, pdCtrl.GetPDClient(), storageApiVersion,
+		cfg.ChecksumConcurrency)
+	err = checksum.Run(ctx, cmdName, executor, checksumMethod, fileChecksum)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }

--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -91,7 +91,7 @@ func NewBackupClient(ctx context.Context, mgr ClientMgr, config *tls.Config) (*C
 	log.Info("new backup client")
 	pdClient := mgr.GetPDClient()
 	clusterID := pdClient.GetClusterID(ctx)
-	curAPIVer, err := GetCurrentTiKVApiVersion(ctx, mgr.GetPDClient(), config)
+	curAPIVer, err := GetTiKVApiVersion(ctx, mgr.GetPDClient(), config)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -142,7 +142,7 @@ func (bc *Client) GetTS(ctx context.Context, duration time.Duration, ts uint64) 
 	return backupTS, nil
 }
 
-func GetCurrentTiKVApiVersion(ctx context.Context, pdClient pd.Client, tlsConf *tls.Config) (kvrpcpb.APIVersion, error) {
+func GetTiKVApiVersion(ctx context.Context, pdClient pd.Client, tlsConf *tls.Config) (kvrpcpb.APIVersion, error) {
 	allStores, err := conn.GetAllTiKVStoresWithRetry(ctx, pdClient, conn.SkipTiFlash)
 	if err != nil {
 		return kvrpcpb.APIVersion_V1, errors.Trace(err)

--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -6,11 +6,8 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -66,14 +63,6 @@ const (
 	RegionUnit ProgressUnit = "region"
 )
 
-type StorageConfig struct {
-	APIVersion int  `json:"api-version"`
-	EnableTTL  bool `json:"enable-ttl"`
-}
-type StoreConfig struct {
-	Storage StorageConfig `json:"storage"`
-}
-
 // Client is a client instructs TiKV how to do a backup.
 type Client struct {
 	mgr       ClientMgr
@@ -91,7 +80,7 @@ func NewBackupClient(ctx context.Context, mgr ClientMgr, config *tls.Config) (*C
 	log.Info("new backup client")
 	pdClient := mgr.GetPDClient()
 	clusterID := pdClient.GetClusterID(ctx)
-	curAPIVer, err := GetTiKVApiVersion(ctx, mgr.GetPDClient(), config)
+	curAPIVer, err := conn.GetTiKVApiVersion(ctx, mgr.GetPDClient(), config)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -140,53 +129,6 @@ func (bc *Client) GetTS(ctx context.Context, duration time.Duration, ts uint64) 
 	}
 	log.Info("backup encode timestamp", zap.Uint64("BackupTS", backupTS))
 	return backupTS, nil
-}
-
-func GetTiKVApiVersion(ctx context.Context, pdClient pd.Client, tlsConf *tls.Config) (kvrpcpb.APIVersion, error) {
-	allStores, err := conn.GetAllTiKVStoresWithRetry(ctx, pdClient, conn.SkipTiFlash)
-	if err != nil {
-		return kvrpcpb.APIVersion_V1, errors.Trace(err)
-	} else if len(allStores) == 0 {
-		return kvrpcpb.APIVersion_V1, errors.New("store are empty")
-	}
-	schema := "http"
-	httpClient := http.Client{}
-	if tlsConf != nil {
-		httpClient = http.Client{
-			Transport: &http.Transport{TLSClientConfig: tlsConf},
-		}
-		schema = "https"
-	}
-	url := fmt.Sprintf("%s://%s/config", schema, allStores[0].StatusAddress)
-	resp, err := httpClient.Get(url)
-	if err != nil {
-		return kvrpcpb.APIVersion_V1, errors.Trace(err)
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return kvrpcpb.APIVersion_V1, errors.Trace(err)
-	}
-	var cfg StoreConfig
-	if err := json.Unmarshal(body, &cfg); err != nil {
-		return kvrpcpb.APIVersion_V1, errors.Trace(err)
-	}
-	var apiVersion kvrpcpb.APIVersion
-	if cfg.Storage.APIVersion == 0 { // in old version without apiversion config. it's APIV1.
-		apiVersion = kvrpcpb.APIVersion_V1
-	} else if cfg.Storage.APIVersion == 1 {
-		if cfg.Storage.EnableTTL {
-			apiVersion = kvrpcpb.APIVersion_V1TTL
-		} else {
-			apiVersion = kvrpcpb.APIVersion_V1
-		}
-	} else if cfg.Storage.APIVersion == 2 {
-		apiVersion = kvrpcpb.APIVersion_V2
-	} else {
-		errMsg := fmt.Sprintf("Invalid apiversion %d", cfg.Storage.APIVersion)
-		return kvrpcpb.APIVersion_V1, errors.New(errMsg)
-	}
-	return apiVersion, nil
 }
 
 func (bc *Client) GetCurAPIVersion() kvrpcpb.APIVersion {

--- a/br/pkg/backup/client_test.go
+++ b/br/pkg/backup/client_test.go
@@ -227,7 +227,7 @@ func (r *testBackup) TestCheckBackupIsLocked(c *C) {
 	c.Assert(err, ErrorMatches, "backup lock file and sst file exist in(.+)")
 }
 
-func (r *testBackup) TestGetCurrentTiKVApiVersion(c *C) {
+func (r *testBackup) TestGetTiKVApiVersion(c *C) {
 	ctx := context.Background()
 
 	httpmock.Activate()
@@ -236,21 +236,21 @@ func (r *testBackup) TestGetCurrentTiKVApiVersion(c *C) {
 	httpmock.RegisterResponder("GET", `=~^/config`,
 		httpmock.NewStringResponder(200, `{"storage":{"api-version":1, "enable-ttl":false}}`))
 
-	apiVer, err := backup.GetCurrentTiKVApiVersion(ctx, r.mockPDClient, nil)
+	apiVer, err := backup.GetTiKVApiVersion(ctx, r.mockPDClient, nil)
 	c.Assert(err, IsNil)
 	c.Assert(apiVer, Equals, kvrpcpb.APIVersion_V1)
 
 	httpmock.RegisterResponder("GET", `=~^/config`,
 		httpmock.NewStringResponder(200, `{"storage":{"api-version":1, "enable-ttl":true}}`))
 
-	apiVer, err = backup.GetCurrentTiKVApiVersion(ctx, r.mockPDClient, nil)
+	apiVer, err = backup.GetTiKVApiVersion(ctx, r.mockPDClient, nil)
 	c.Assert(err, IsNil)
 	c.Assert(apiVer, Equals, kvrpcpb.APIVersion_V1TTL)
 
 	httpmock.RegisterResponder("GET", `=~^/config`,
 		httpmock.NewStringResponder(200, `{"storage":{"api-version":2, "enable-ttl":true}}`))
 
-	apiVer, err = backup.GetCurrentTiKVApiVersion(ctx, r.mockPDClient, nil)
+	apiVer, err = backup.GetTiKVApiVersion(ctx, r.mockPDClient, nil)
 	c.Assert(err, IsNil)
 	c.Assert(apiVer, Equals, kvrpcpb.APIVersion_V2)
 }

--- a/br/pkg/backup/client_test.go
+++ b/br/pkg/backup/client_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/pingcap/check"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/kvproto/pkg/errorpb"
-	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/testutils"
 	"github.com/tikv/client-go/v2/tikv"
@@ -225,32 +224,4 @@ func (r *testBackup) TestCheckBackupIsLocked(c *C) {
 	c.Assert(err, IsNil)
 	err = backup.CheckBackupStorageIsLocked(ctx, r.storage)
 	c.Assert(err, ErrorMatches, "backup lock file and sst file exist in(.+)")
-}
-
-func (r *testBackup) TestGetTiKVApiVersion(c *C) {
-	ctx := context.Background()
-
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-	// Exact URL match
-	httpmock.RegisterResponder("GET", `=~^/config`,
-		httpmock.NewStringResponder(200, `{"storage":{"api-version":1, "enable-ttl":false}}`))
-
-	apiVer, err := backup.GetTiKVApiVersion(ctx, r.mockPDClient, nil)
-	c.Assert(err, IsNil)
-	c.Assert(apiVer, Equals, kvrpcpb.APIVersion_V1)
-
-	httpmock.RegisterResponder("GET", `=~^/config`,
-		httpmock.NewStringResponder(200, `{"storage":{"api-version":1, "enable-ttl":true}}`))
-
-	apiVer, err = backup.GetTiKVApiVersion(ctx, r.mockPDClient, nil)
-	c.Assert(err, IsNil)
-	c.Assert(apiVer, Equals, kvrpcpb.APIVersion_V1TTL)
-
-	httpmock.RegisterResponder("GET", `=~^/config`,
-		httpmock.NewStringResponder(200, `{"storage":{"api-version":2, "enable-ttl":true}}`))
-
-	apiVer, err = backup.GetTiKVApiVersion(ctx, r.mockPDClient, nil)
-	c.Assert(err, IsNil)
-	c.Assert(apiVer, Equals, kvrpcpb.APIVersion_V2)
 }

--- a/br/pkg/checksum/executor.go
+++ b/br/pkg/checksum/executor.go
@@ -334,7 +334,7 @@ func (exec *Executor) Execute(
 func Run(ctx context.Context, cmdName string,
 	executor *Executor, method StorageChecksumMethod, expect Checksum) error {
 	if executor.apiVersion != kvrpcpb.APIVersion_V1 {
-		fmt.Printf("\033[1;37;41m%s\033[0m\n", "TiKV cluster is TTL enabled, checksum may be mismatch if some data expired during backup/restore.")
+		fmt.Printf("\033[1;37;41m%s\033[0m\n", "Warning: TiKV cluster is TTL enabled, checksum may be mismatch if some data expired during backup/restore.")
 	}
 	glue := new(gluetikv.Glue)
 	updateCh := glue.StartProgress(ctx, cmdName+" Checksum", int64(len(executor.keyRanges)), false)

--- a/br/pkg/checksum/executor.go
+++ b/br/pkg/checksum/executor.go
@@ -333,6 +333,9 @@ func (exec *Executor) Execute(
 
 func Run(ctx context.Context, cmdName string,
 	executor *Executor, method StorageChecksumMethod, expect Checksum) error {
+	if executor.apiVersion != kvrpcpb.APIVersion_V1 {
+		fmt.Printf("\033[1;37;41m%s\033[0m\n", "TiKV cluster is TTL enabled, checksum may be mismatch if some data expired during backup/restore.")
+	}
 	glue := new(gluetikv.Glue)
 	updateCh := glue.StartProgress(ctx, cmdName+" Checksum", int64(len(executor.keyRanges)), false)
 	progressCallBack := func(unit backup.ProgressUnit) {

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -12,8 +12,10 @@ import (
 	"github.com/pingcap/errors"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/kvproto/pkg/import_sstpb"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/log"
 	"github.com/tikv/client-go/v2/oracle"
+	"github.com/tikv/migration/br/pkg/backup"
 	"github.com/tikv/migration/br/pkg/conn"
 	berrors "github.com/tikv/migration/br/pkg/errors"
 	"github.com/tikv/migration/br/pkg/glue"
@@ -43,7 +45,8 @@ type Client struct {
 	tlsConf       *tls.Config
 	keepaliveConf keepalive.ClientParameters
 
-	backupMeta *backuppb.BackupMeta
+	backupMeta    *backuppb.BackupMeta
+	dstAPIVersion kvrpcpb.APIVersion
 
 	rateLimit       uint64
 	isOnline        bool
@@ -64,12 +67,17 @@ func NewRestoreClient(
 	keepaliveConf keepalive.ClientParameters,
 	isRawKv bool,
 ) (*Client, error) {
+	apiVerion, err := backup.GetTiKVApiVersion(context.Background(), pdClient, tlsConf)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return &Client{
 		pdClient:      pdClient,
 		toolClient:    NewSplitClient(pdClient, tlsConf, isRawKv),
 		tlsConf:       tlsConf,
 		keepaliveConf: keepaliveConf,
 		switchCh:      make(chan struct{}),
+		dstAPIVersion: apiVerion,
 	}, nil
 }
 
@@ -397,4 +405,8 @@ func (rc *Client) switchTiKVMode(ctx context.Context, mode import_sstpb.SwitchMo
 		}
 	}
 	return nil
+}
+
+func (rc *Client) GetAPIVersion() kvrpcpb.APIVersion {
+	return rc.dstAPIVersion
 }

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/log"
 	"github.com/tikv/client-go/v2/oracle"
-	"github.com/tikv/migration/br/pkg/backup"
 	"github.com/tikv/migration/br/pkg/conn"
 	berrors "github.com/tikv/migration/br/pkg/errors"
 	"github.com/tikv/migration/br/pkg/glue"
@@ -67,7 +66,7 @@ func NewRestoreClient(
 	keepaliveConf keepalive.ClientParameters,
 	isRawKv bool,
 ) (*Client, error) {
-	apiVerion, err := backup.GetTiKVApiVersion(context.Background(), pdClient, tlsConf)
+	apiVerion, err := conn.GetTiKVApiVersion(context.Background(), pdClient, tlsConf)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/br/pkg/task/common.go
+++ b/br/pkg/task/common.go
@@ -95,7 +95,7 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 
 	flags.Uint64(flagRateLimit, unlimited, "The rate limit of the task, MB/s per node")
 	_ = flags.MarkHidden(flagRateLimit)
-	flags.Bool(flagChecksum, true, "Run checksum at end of task")
+	flags.Bool(flagChecksum, false, "Run checksum at end of task")
 	// Default concurrency is different for backup and restore.
 	// Leave it 0 and let them adjust the value.
 	flags.Uint32(flagConcurrency, 0, "The size of thread pool on each node that executes the task")

--- a/br/pkg/task/common.go
+++ b/br/pkg/task/common.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pingcap/errors"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/kvproto/pkg/encryptionpb"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -364,4 +365,10 @@ func normalizePDURL(pd string, useTLS bool) (string, error) {
 // see details https://github.com/pingcap/br/issues/675#issuecomment-753780742
 func gcsObjectNotFound(err error) bool {
 	return errors.Cause(err) == gcs.ErrObjectNotExist // nolint:errorlint
+}
+
+// CheckBackupAPIVersion return false if backup api version is not supported.
+func CheckBackupAPIVersion(storageAPIVersion, dstAPIVersion kvrpcpb.APIVersion) bool {
+	// only support apiv1/v1ttl->apiv2 if apiversions are not the same.
+	return storageAPIVersion == dstAPIVersion || dstAPIVersion == kvrpcpb.APIVersion_V2
 }

--- a/br/pkg/task/common_test.go
+++ b/br/pkg/task/common_test.go
@@ -9,6 +9,7 @@ import (
 
 	backup "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/kvproto/pkg/encryptionpb"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 )
@@ -147,4 +148,16 @@ func TestCheckCipherKey(t *testing.T) {
 			require.Error(t, err)
 		}
 	}
+}
+
+func TestCheckBackupAPIVersion(t *testing.T) {
+	require.Equal(t, CheckBackupAPIVersion(kvrpcpb.APIVersion_V1, kvrpcpb.APIVersion_V1), true)
+	require.Equal(t, CheckBackupAPIVersion(kvrpcpb.APIVersion_V1TTL, kvrpcpb.APIVersion_V1TTL), true)
+	require.Equal(t, CheckBackupAPIVersion(kvrpcpb.APIVersion_V2, kvrpcpb.APIVersion_V2), true)
+	require.Equal(t, CheckBackupAPIVersion(kvrpcpb.APIVersion_V1, kvrpcpb.APIVersion_V2), true)
+	require.Equal(t, CheckBackupAPIVersion(kvrpcpb.APIVersion_V1TTL, kvrpcpb.APIVersion_V2), true)
+	require.Equal(t, CheckBackupAPIVersion(kvrpcpb.APIVersion_V1, kvrpcpb.APIVersion_V1TTL), false)
+	require.Equal(t, CheckBackupAPIVersion(kvrpcpb.APIVersion_V1TTL, kvrpcpb.APIVersion_V1), false)
+	require.Equal(t, CheckBackupAPIVersion(kvrpcpb.APIVersion_V2, kvrpcpb.APIVersion_V1), false)
+	require.Equal(t, CheckBackupAPIVersion(kvrpcpb.APIVersion_V2, kvrpcpb.APIVersion_V1TTL), false)
 }

--- a/br/pkg/task/restore_raw.go
+++ b/br/pkg/task/restore_raw.go
@@ -64,8 +64,12 @@ func RunRestoreRaw(c context.Context, g glue.Glue, cmdName string, cfg *RestoreR
 	if err != nil {
 		return errors.Trace(err)
 	}
+	if client.GetAPIVersion() != backupMeta.ApiVersion {
+		return errors.Errorf("Unsupported backup api version, backup meta: %s, dst:%s.",
+			backupMeta.ApiVersion.String(), client.GetAPIVersion().String())
+	}
 	// for restore, dst and cur are the same.
-	cfg.DstAPIVersion = backupMeta.ApiVersion.String()
+	cfg.DstAPIVersion = client.GetAPIVersion().String()
 	cfg.adjustBackupRange(backupMeta.ApiVersion)
 	reader := metautil.NewMetaReader(backupMeta, s, &cfg.CipherInfo)
 	if err = client.InitBackupMeta(c, backupMeta, u, s, reader); err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #108 

Problem Description: 
Checksum maybe mismatch if data expired during backup/restore.

### What is changed and how does it work?
1. Add a warning that "Warning: TiKV cluster is TTL enabled, checksum may be mismatch if some data expired during backup/restore."
2. Implement checksum debug command.
3. Add api version check to reject the invalid backup/restore operation.

### Code changes

<!-- REMOVE the items that are not applicable -->
- Has exported function/method change


### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test
- Manual test (add detailed scripts or steps below)

### Side effects

<!-- REMOVE the items that are not applicable -->
- No side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- No related changes
