### PR TITLE
[close #128] Fix TestClientErrNoPendingRegion

### DIFF
--- a/cdc/cdc/kv/client_test.go
+++ b/cdc/cdc/kv/client_test.go
@@ -2899,11 +2899,14 @@ func (s *clientSuite) testClientErrNoPendingRegion(c *check.C) {
 	}()
 
 	baseAllocatedID := currentRequestID()
+	log.Error("testClientErrNoPendingRegion 0", zap.Uint64("baseAllocatedID", baseAllocatedID))
 	// wait the second region is scheduled
 	time.Sleep(time.Millisecond * 500)
+	log.Error("waitRequestID 1", zap.Uint64("baseAllocatedID+1", baseAllocatedID+1))
 	waitRequestID(c, baseAllocatedID+1)
 	initialized := mockInitializedEvent(regionID3, currentRequestID())
 	ch1 <- initialized
+	log.Error("waitRequestID 2", zap.Uint64("baseAllocatedID+2", baseAllocatedID+2))
 	waitRequestID(c, baseAllocatedID+2)
 	initialized = mockInitializedEvent(regionID4, currentRequestID())
 	ch1 <- initialized


### PR DESCRIPTION
Signed-off-by: pingyu <yuping@pingcap.com>

<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #128 

Problem Description: [`clientSuite.TestClientErrNoPendingRegion`](https://github.com/tikv/migration/blob/b3c6c9b059588edb5f38a2b7a8868c71d1a5a2bc/cdc/cdc/kv/client_test.go#L2848) is not stable.


### What is changed and how does it work?
Make test cases in [`clientSuite`](https://github.com/tikv/migration/blob/main/cdc/cdc/kv/client_test.go) be serial.
Move `baseAllocatedID` to be acquired before `EventFeed` goroutine to ensure the correctness of base value.

Note that I'm not sure this PR will fix the issue. Although I re-run the CI and all of them are successful. If the failure happen again, reopen the issue.

### Code changes

<!-- REMOVE the items that are not applicable -->

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test

### Side effects

### Related changes
