### PR TITLE
[close #145] Change binary name to support product release

### DIFF
--- a/cdc/Makefile
+++ b/cdc/Makefile
@@ -90,14 +90,14 @@ bank:
 
 build-failpoint: check_failpoint_ctl
 	$(FAILPOINT_ENABLE)
-	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/cdc ./cmd/cdc/main.go
+	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/tikv-cdc ./cmd/cdc/main.go
 	$(FAILPOINT_DISABLE)
 
 cdc:
-	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/cdc ./cmd/cdc/main.go
+	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/tikv-cdc ./cmd/cdc/main.go
 
 debug:
-	$(GOBUILD_DEBUG) -ldflags '$(LDFLAGS)' -o bin/cdc ./cmd/cdc/main.go
+	$(GOBUILD_DEBUG) -ldflags '$(LDFLAGS)' -o bin/tikv-cdc ./cmd/cdc/main.go
 
 kafka_consumer:
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/cdc_kafka_consumer ./cmd/kafka-consumer/main.go

--- a/gc-worker/Makefile
+++ b/gc-worker/Makefile
@@ -24,10 +24,11 @@ GCWORKER_PKG   := github.com/tikv/migration/gc-worker
 
 LDFLAGS += -X "$(GCWORKER_PKG)/server.GCWorkerVersion=$(shell git describe --tags --dirty --always)"
 #### Build ####
-build: gc-worker
+build: 
+	$(GO) build -tags codes -gcflags "all=-N -l" -ldflags '$(LDFLAGS)' -o $(BUILD_BIN_PATH)/tikv-gc-worker cmd/*.go
 
-gc-worker: 
-	$(GO) build -tags codes -gcflags "all=-N -l" -ldflags '$(LDFLAGS)' -o $(BUILD_BIN_PATH)/gc-worker cmd/*.go
+release: 
+	$(GO) build -tags codes -ldflags '$(LDFLAGS)' -o $(BUILD_BIN_PATH)/tikv-gc-worker cmd/*.go
  
 check: check/golangci-lint check/gosec
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #145 

Problem Description:  change binary name to support product release.

### What is changed and how does it work?
1. change cdc binary name to tikv-cdc
2. change gc-worker binary name to tikv-gc-worker
tag name is defined as `br-v1.0.0` `cdc-v1.0.0` `gc-worker-v1.0.0` to distinguish different products.

release test is as following in my private repos:  
<img width="581" alt="image" src="https://user-images.githubusercontent.com/10524249/177479752-e8a3c5af-0eab-4a2c-a542-fd9c7b765bad.png">

 
### Code changes

<!-- REMOVE the items that are not applicable -->
- No code

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Manual test (add detailed scripts or steps below)
- No code

### Side effects

<!-- REMOVE the items that are not applicable -->
- No side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- No related changes
