### PR TITLE
[close #164] Fix processor query

### DIFF
--- a/cdc/cdc/capture/http_handler.go
+++ b/cdc/cdc/capture/http_handler.go
@@ -593,10 +593,10 @@ func (h *HTTPHandler) GetProcessor(c *gin.Context) {
 		processorDetail = model.ProcessorDetail{
 			CheckPointTs: position.CheckPointTs,
 			ResolvedTs:   position.ResolvedTs,
+			KeySpans:     status.KeySpans,
 			Count:        position.Count,
 			Error:        position.Error,
 		}
-		processorDetail.KeySpans = status.KeySpans
 	}
 	c.IndentedJSON(http.StatusOK, &processorDetail)
 }

--- a/cdc/cdc/capture/http_handler.go
+++ b/cdc/cdc/capture/http_handler.go
@@ -596,11 +596,7 @@ func (h *HTTPHandler) GetProcessor(c *gin.Context) {
 			Count:        position.Count,
 			Error:        position.Error,
 		}
-		keyspans := make([]uint64, 0)
-		for keyspanID := range status.KeySpans {
-			keyspans = append(keyspans, keyspanID)
-		}
-		processorDetail.KeySpans = keyspans
+		processorDetail.KeySpans = status.KeySpans
 	}
 	c.IndentedJSON(http.StatusOK, &processorDetail)
 }

--- a/cdc/cdc/model/http_model.go
+++ b/cdc/cdc/model/http_model.go
@@ -146,7 +146,7 @@ type ProcessorDetail struct {
 	CheckPointTs uint64 `json:"checkpoint_ts"`
 	// The event that satisfies CommitTs <= ResolvedTs can be synchronized.
 	ResolvedTs uint64 `json:"resolved_ts"`
-	// all keyspan ids that this processor are replicating
+	// all keyspan that this processor are replicating
 	KeySpans map[KeySpanID]*KeySpanReplicaInfo `json:"keyspans"`
 	// The count of events that have been replicated.
 	Count uint64 `json:"count"`

--- a/cdc/cdc/model/http_model.go
+++ b/cdc/cdc/model/http_model.go
@@ -147,7 +147,7 @@ type ProcessorDetail struct {
 	// The event that satisfies CommitTs <= ResolvedTs can be synchronized.
 	ResolvedTs uint64 `json:"resolved_ts"`
 	// all keyspan ids that this processor are replicating
-	KeySpans []uint64 `json:"keyspan_ids"`
+	KeySpans map[KeySpanID]*KeySpanReplicaInfo `json:"keyspans"`
 	// The count of events that have been replicated.
 	Count uint64 `json:"count"`
 	// Error code when error happens

--- a/cdc/cdc/model/owner.go
+++ b/cdc/cdc/model/owner.go
@@ -216,9 +216,9 @@ func (w *TaskWorkload) Marshal() (string, error) {
 
 // KeySpanReplicaInfo records the keyspan replica info
 type KeySpanReplicaInfo struct {
-	StartTs Ts `json:"start-ts"`
-	Start   []byte
-	End     []byte
+	StartTs Ts     `json:"start-ts"`
+	Start   []byte `json:"start"`
+	End     []byte `json:"end"`
 }
 
 // Clone clones a KeySpanReplicaInfo

--- a/cdc/cdc/model/owner_test.go
+++ b/cdc/cdc/model/owner_test.go
@@ -220,7 +220,7 @@ func TestTaskStatusMarshal(t *testing.T) {
 			1: {StartTs: 420875942036766723},
 		},
 	}
-	expected := `{"keyspans":{"1":{"start-ts":420875942036766723,"Start":null,"End":null}},"operation":null,"admin-job-type":0}`
+	expected := `{"keyspans":{"1":{"start-ts":420875942036766723,"start":null,"end":null}},"operation":null,"admin-job-type":0}`
 
 	data, err := status.Marshal()
 	require.Nil(t, err)

--- a/cdc/pkg/cmd/cli/cli_processor_query.go
+++ b/cdc/pkg/cmd/cli/cli_processor_query.go
@@ -121,18 +121,9 @@ func (o *queryProcessorOptions) runCliWithAPIClient(ctx context.Context, cmd *co
 		return err
 	}
 
-	keyspans := make(map[uint64]*model.KeySpanReplicaInfo)
-	for _, keyspanID := range processor.KeySpans {
-		keyspans[keyspanID] = &model.KeySpanReplicaInfo{
-			// to be compatible with old version `cli processor query`,
-			// set this field to 0
-			StartTs: 0,
-		}
-	}
-
 	meta := &processorMeta{
 		Status: &model.TaskStatus{
-			KeySpans: keyspans,
+			KeySpans: processor.KeySpans,
 			// Operations, AdminJobType and ModRevision are vacant
 		},
 		Position: &model.TaskPosition{


### PR DESCRIPTION
<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #] summary" -->

### What problem does this PR solve?

fix processor query

Issue Number: close #164

Problem Description: 

The start-key and end-key in the result returned by the command tikv-cdc processor query are nil.

### What is changed and how does it work?

Use map[KeySpanID]*KeySpanReplicaInfo instead of []KeySpanID as result.

### Code changes

<!-- REMOVE the items that are not applicable -->
- Has exported function/method change


### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test
- Manual test (add detailed scripts or steps below)

