### PR TITLE
[close #177] fix unstable client_test

### DIFF
--- a/cdc/cdc/kv/client_test.go
+++ b/cdc/cdc/kv/client_test.go
@@ -642,7 +642,7 @@ consumePreResolvedTs:
 		case event = <-eventCh:
 			c.Assert(event.Resolved, check.NotNil)
 			c.Assert(event.Resolved.ResolvedTs, check.Equals, uint64(100))
-		case <-time.After(time.Second):
+		case <-time.After(3 * time.Second):
 			break consumePreResolvedTs
 		}
 	}
@@ -673,8 +673,8 @@ consumePreResolvedTs:
 	ch2 <- makeEvent(120)
 	select {
 	case event = <-eventCh:
-	case <-time.After(3 * time.Second):
-		c.Fatalf("reconnection not succeed in 3 seconds")
+	case <-time.After(10 * time.Second):
+		c.Fatalf("reconnection not succeed in 10 seconds")
 	}
 	c.Assert(event.Resolved, check.NotNil)
 	c.Assert(event.Resolved.ResolvedTs, check.Equals, uint64(120))


### PR DESCRIPTION
Signed-off-by: pingyu <yuping@pingcap.com>

<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #177 

Problem Description: `client_test.TestHandleError` is not stable.

### What is changed and how does it work?
The issue seems to be caused by the insufficient of the 3 seconds' waiting duration. Maybe the CI env is busy.
Just prolong the duration to 10 seconds.

### Code changes

<!-- REMOVE the items that are not applicable -->

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test

### Side effects

<!-- REMOVE the items that are not applicable -->
- No side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- No related changes
