### PR TITLE
[close #163] fix processor list

### DIFF
--- a/cdc/pkg/cmd/cli/cli_processor_list.go
+++ b/cdc/pkg/cmd/cli/cli_processor_list.go
@@ -88,11 +88,17 @@ func (o *listProcessorOptions) run(cmd *cobra.Command) error {
 		return util.JSONPrint(cmd, processors)
 	}
 
-	info, err := o.etcdClient.GetProcessors(ctx)
+	infos, err := o.etcdClient.GetProcessors(ctx)
 	if err != nil {
 		return err
 	}
-	return util.JSONPrint(cmd, info)
+	processors := []*model.ProcInfoSnap{}
+	for _, info := range infos {
+		if len(info.KeySpans) != 0 {
+			processors = append(processors, info)
+		}
+	}
+	return util.JSONPrint(cmd, processors)
 }
 
 // newCmdListProcessor creates the `cli processor list` command.


### PR DESCRIPTION
Signed-off-by: zeminzhou <zhouzemin@pingcap.com>

<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

tikv-cdc cli processor list will return all cdc capture when  `runWithAPIClient` disable.

Issue Number: close #163

Problem Description: **TBD**

tikv-cdc cli processor list will return all cdc capture when  `runWithAPIClient` disable.

### What is changed and how does it work?

only return the captures that processing data

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Manual test (add detailed scripts or steps below)