### PR TITLE
[close #200] CDC & BR version check with new tag naming style

### DIFF
--- a/br/pkg/version/version.go
+++ b/br/pkg/version/version.go
@@ -30,6 +30,7 @@ var (
 func removeVAndHash(v string) string {
 	v = versionHash.ReplaceAllLiteralString(v, "")
 	v = strings.TrimSuffix(v, "-dirty")
+	v = strings.TrimPrefix(v, "br-") // tag is named with br-vx.x.x
 	return strings.TrimPrefix(v, "v")
 }
 

--- a/br/pkg/version/version_test.go
+++ b/br/pkg/version/version_test.go
@@ -46,7 +46,7 @@ func TestCheckClusterVersion(t *testing.T) {
 	}
 
 	{
-		build.ReleaseVersion = "v0.1"
+		build.ReleaseVersion = "br-v0.1"
 		mock.getAllStores = func() []*metapb.Store {
 			return tiflash("v4.0.0-rc.1")
 		}
@@ -56,7 +56,7 @@ func TestCheckClusterVersion(t *testing.T) {
 	}
 
 	{
-		build.ReleaseVersion = "v3.1.0-beta.2"
+		build.ReleaseVersion = "br-v3.1.0-beta.2"
 		mock.getAllStores = func() []*metapb.Store {
 			return []*metapb.Store{{Version: minTiKVVersion.String()}}
 		}
@@ -65,7 +65,16 @@ func TestCheckClusterVersion(t *testing.T) {
 	}
 
 	{
-		build.ReleaseVersion = "v0.1.0"
+		build.ReleaseVersion = "rb-v3.1.0-beta.2"
+		mock.getAllStores = func() []*metapb.Store {
+			return []*metapb.Store{{Version: minTiKVVersion.String()}}
+		}
+		err := CheckClusterVersion(context.Background(), &mock, CheckVersionForBR)
+		require.Regexp(t, `rb is not in dotted-tri format`, err.Error())
+	}
+
+	{
+		build.ReleaseVersion = "br-v0.1.0"
 		mock.getAllStores = func() []*metapb.Store {
 			return []*metapb.Store{{Version: "v6.1.0"}}
 		}

--- a/cdc/Makefile
+++ b/cdc/Makefile
@@ -44,8 +44,8 @@ FAILPOINT_DISABLE := $$(echo $(FAILPOINT_DIR) | xargs $(FAILPOINT) disable >/dev
 RELEASE_VERSION =
 ifeq ($(RELEASE_VERSION),)
 	RELEASE_VERSION := v1.0.0-master
-	release_version_regex := ^v[0-9]\..*$$
-	release_branch_regex := "^release-[0-9]\.[0-9].*$$|^HEAD$$|^.*/*tags/v[0-9]\.[0-9]\..*$$"
+	release_version_regex := ^cdc-v[0-9]\..*$$
+	release_branch_regex := "^cdc-[0-9]\.[0-9].*$$|^HEAD$$|^.*/*tags/cdc-v[0-9]\.[0-9]\..*$$"
 	ifneq ($(shell git rev-parse --abbrev-ref HEAD | egrep $(release_branch_regex)),)
 		# If we are in release branch, try to use tag version.
 		ifneq ($(shell git describe --tags --dirty | egrep $(release_version_regex)),)

--- a/cdc/pkg/version/check.go
+++ b/cdc/pkg/version/check.go
@@ -65,6 +65,7 @@ func removeVAndHash(v string) string {
 	}
 	v = versionHash.ReplaceAllLiteralString(v, "")
 	v = strings.TrimSuffix(v, "-dirty")
+	v = strings.TrimPrefix(v, "cdc-") // tag is named with cdc-vx.x.x
 	return strings.TrimPrefix(v, "v")
 }
 


### PR DESCRIPTION
Signed-off-by: haojinming <jinming.hao@pingcap.com>

<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #200 

Problem Description: 

### What is changed and how does it work?
1. New tag naming stype is br-vx.x.x or cdc-vx.x.x, which cause version check issue in BR and CDC
2. Remove `br` or `cdc` prefix before version check.

### Code changes

<!-- REMOVE the items that are not applicable -->


### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test

### Side effects

<!-- REMOVE the items that are not applicable -->
- No side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- No related changes
