### PR TITLE
[close #245] update sstdecoder  with alternative options

### DIFF
--- a/sst-data-source/src/main/java/org/tikv/datasources/br/SSTDecoder.java
+++ b/sst-data-source/src/main/java/org/tikv/datasources/br/SSTDecoder.java
@@ -55,9 +55,9 @@ public class SSTDecoder {
       throw new RocksDBException("File already opened!");
     }
 
-    sstFileReader = new SstFileReader(new Options());
+    sstFileReader = new SstFileReader(options);
     sstFileReader.open(filePath);
-    iterator = sstFileReader.newIterator(new ReadOptions());
+    iterator = sstFileReader.newIterator(readOptions);
     return new SSTIterator(iterator, kvDecoder);
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #245

Problem Description: **In the project Spark SST Data Source , SSTDecoder class supports to be constructed with options and ReadOptions for rocksdb, but  it seems like doesn't work when reading from sst**

### What is changed and how does it work?


### Code changes

<!-- REMOVE the items that are not applicable -->
- Has exported function/method change

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test
- Integration test

