### PR TITLE
[close #267] Fix restore ratelimit

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -240,7 +240,7 @@ func (rc *Client) setSpeedLimit(ctx context.Context, rateLimit uint64) error {
 	return nil
 }
 
-func (rc *Client) resetSpeedLimit(ctx context.Context) error {
+func (rc *Client) resetSpeedLimit(ctx context.Context) {
 	if rc.hasSpeedLimited {
 		var resetErr error
 		for retry := 0; retry < resetSpeedLimitRetryTimes; retry++ {
@@ -258,7 +258,6 @@ func (rc *Client) resetSpeedLimit(ctx context.Context) error {
 		}
 	}
 	rc.hasSpeedLimited = false
-	return nil
 }
 
 // RestoreRaw tries to restore raw keys in the specified range.

--- a/br/pkg/restore/client_test.go
+++ b/br/pkg/restore/client_test.go
@@ -1,0 +1,143 @@
+// Copyright 2020 PingCAP, Inc. Licensed under Apache-2.0.
+
+package restore
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/pingcap/kvproto/pkg/import_sstpb"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/stretchr/testify/require"
+	pd "github.com/tikv/pd/client"
+	"google.golang.org/grpc/keepalive"
+)
+
+var defaultKeepaliveCfg = keepalive.ClientParameters{
+	Time:    3 * time.Second,
+	Timeout: 10 * time.Second,
+}
+
+type fakePDClient struct {
+	pd.Client
+	stores []*metapb.Store
+}
+
+func (fpdc fakePDClient) GetAllStores(context.Context, ...pd.GetStoreOption) ([]*metapb.Store, error) {
+	return append([]*metapb.Store{}, fpdc.stores...), nil
+}
+
+// Mock ImporterClient interface
+type FakeImporterClient struct {
+	ImporterClient
+}
+
+// Record the stores that have communicated
+type RecordStores struct {
+	mu     sync.Mutex
+	stores map[uint64]uint64
+}
+
+func NewRecordStores() RecordStores {
+	return RecordStores{stores: make(map[uint64]uint64, 0)}
+}
+
+func (r *RecordStores) put(id uint64, rateLimit uint64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stores[id] = rateLimit
+}
+
+func (r *RecordStores) len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.stores)
+}
+
+func (r *RecordStores) get(id uint64) uint64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.stores[id]
+}
+
+func (r *RecordStores) toString() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return fmt.Sprintf("%v", r.stores)
+}
+
+var recordStores RecordStores
+
+const (
+	WORKING_TIME = 10
+)
+
+func (fakeImportCli FakeImporterClient) SetDownloadSpeedLimit(
+	ctx context.Context,
+	storeID uint64,
+	req *import_sstpb.SetDownloadSpeedLimitRequest,
+) (*import_sstpb.SetDownloadSpeedLimitResponse, error) {
+	time.Sleep(WORKING_TIME * time.Millisecond) // simulate doing 100 ms work
+	recordStores.put(storeID, req.SpeedLimit)
+	return nil, nil
+}
+
+func TestSetSpeedLimit(t *testing.T) {
+	mockStores := []*metapb.Store{
+		{Id: 1},
+		{Id: 2},
+		{Id: 3},
+		{Id: 4},
+		{Id: 5},
+		{Id: 6},
+		{Id: 7},
+		{Id: 8},
+		{Id: 9},
+		{Id: 10},
+	}
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	// Exact URL match
+	httpmock.RegisterResponder("GET", `=~^/config`,
+		httpmock.NewStringResponder(200, `{"storage":{"api-version":2, "enable-ttl":true}}`))
+	// 1. The cost of concurrent communication is expected to be less than the cost of serial communication.
+	client, err := NewRestoreClient(fakePDClient{
+		stores: mockStores,
+	}, nil, defaultKeepaliveCfg, true)
+	require.NoError(t, err)
+	client.fileImporter = NewFileImporter(nil, FakeImporterClient{}, nil, true, kvrpcpb.APIVersion_V2)
+	ctx := context.Background()
+
+	rateLimit := uint64(10)
+	recordStores = NewRecordStores()
+	start := time.Now()
+	err = client.setSpeedLimit(ctx, rateLimit)
+	cost := time.Since(start)
+	require.NoError(t, err)
+
+	t.Logf("Total Cost: %v\n", cost)
+	t.Logf("Has Communicated: %v\n", recordStores.toString())
+
+	serialCost := time.Duration(len(mockStores)*WORKING_TIME) * time.Millisecond
+	require.LessOrEqual(t, serialCost, cost)
+	require.Equal(t, len(mockStores), recordStores.len())
+	for i := 0; i < len(mockStores); i++ {
+		require.Equal(t, rateLimit, recordStores.get(mockStores[i].Id))
+	}
+
+	recordStores = NewRecordStores()
+	start = time.Now()
+	err = client.resetSpeedLimit(ctx)
+	cost = time.Since(start)
+	require.NoError(t, err)
+	require.LessOrEqual(t, serialCost, cost)
+	require.Equal(t, len(mockStores), recordStores.len())
+	for i := 0; i < len(mockStores); i++ {
+		require.Equal(t, uint64(0), recordStores.get(mockStores[i].Id))
+	}
+}

--- a/br/pkg/restore/client_test.go
+++ b/br/pkg/restore/client_test.go
@@ -73,16 +73,14 @@ func (r *RecordStores) toString() string {
 
 var recordStores RecordStores
 
-const (
-	WORKING_TIME = 10
-)
+const workingTime = 10
 
 func (fakeImportCli FakeImporterClient) SetDownloadSpeedLimit(
 	ctx context.Context,
 	storeID uint64,
 	req *import_sstpb.SetDownloadSpeedLimitRequest,
 ) (*import_sstpb.SetDownloadSpeedLimitResponse, error) {
-	time.Sleep(WORKING_TIME * time.Millisecond) // simulate doing 100 ms work
+	time.Sleep(workingTime * time.Millisecond) // simulate doing 100 ms work
 	recordStores.put(storeID, req.SpeedLimit)
 	return nil, nil
 }
@@ -123,7 +121,7 @@ func TestSetSpeedLimit(t *testing.T) {
 	t.Logf("Total Cost: %v\n", cost)
 	t.Logf("Has Communicated: %v\n", recordStores.toString())
 
-	serialCost := time.Duration(len(mockStores)*WORKING_TIME) * time.Millisecond
+	serialCost := time.Duration(len(mockStores)*workingTime) * time.Millisecond
 	require.LessOrEqual(t, serialCost, cost)
 	require.Equal(t, len(mockStores), recordStores.len())
 	for i := 0; i < len(mockStores); i++ {
@@ -132,9 +130,8 @@ func TestSetSpeedLimit(t *testing.T) {
 
 	recordStores = NewRecordStores()
 	start = time.Now()
-	err = client.resetSpeedLimit(ctx)
+	client.resetSpeedLimit(ctx)
 	cost = time.Since(start)
-	require.NoError(t, err)
 	require.LessOrEqual(t, serialCost, cost)
 	require.Equal(t, len(mockStores), recordStores.len())
 	for i := 0; i < len(mockStores); i++ {

--- a/br/pkg/restore/import.go
+++ b/br/pkg/restore/import.go
@@ -201,7 +201,6 @@ type FileImporter struct {
 	metaClient   SplitClient
 	importClient ImporterClient
 	backend      *backuppb.StorageBackend
-	rateLimit    uint64
 
 	isRawKvMode        bool
 	sstAPIVersion      kvrpcpb.APIVersion
@@ -217,7 +216,6 @@ func NewFileImporter(
 	backend *backuppb.StorageBackend,
 	isRawKvMode bool,
 	apiVersion kvrpcpb.APIVersion,
-	rateLimit uint64,
 ) FileImporter {
 	return FileImporter{
 		metaClient:    metaClient,
@@ -225,7 +223,6 @@ func NewFileImporter(
 		importClient:  importClient,
 		isRawKvMode:   isRawKvMode,
 		sstAPIVersion: apiVersion,
-		rateLimit:     rateLimit,
 	}
 }
 
@@ -451,10 +448,9 @@ func (importer *FileImporter) Import(
 	return errors.Trace(err)
 }
 
-// nolint:unused
-func (importer *FileImporter) setDownloadSpeedLimit(ctx context.Context, storeID uint64) error {
+func (importer *FileImporter) setDownloadSpeedLimit(ctx context.Context, storeID uint64, rateLimit uint64) error {
 	req := &import_sstpb.SetDownloadSpeedLimitRequest{
-		SpeedLimit: importer.rateLimit,
+		SpeedLimit: rateLimit,
 	}
 	_, err := importer.importClient.SetDownloadSpeedLimit(ctx, storeID, req)
 	return errors.Trace(err)

--- a/br/pkg/task/restore_raw.go
+++ b/br/pkg/task/restore_raw.go
@@ -45,7 +45,7 @@ func RunRestoreRaw(c context.Context, g glue.Glue, cmdName string, cfg *RestoreR
 	// sometimes we have pooled the connections.
 	// sending heartbeats in idle times is useful.
 	keepaliveCfg.PermitWithoutStream = true
-	client, err := restore.NewRestoreClient(g, mgr.GetPDClient(), mgr.GetTLSConfig(), keepaliveCfg, true)
+	client, err := restore.NewRestoreClient(mgr.GetPDClient(), mgr.GetTLSConfig(), keepaliveCfg, true)
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
Signed-off-by: haojinming <jinming.hao@pingcap.com>

<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #267 

Problem Description: 

### What is changed and how does it work?

Restore does not send `SetDownloadSpeedLimitRequest`. 

### Code changes

<!-- REMOVE the items that are not applicable -->
- Has exported function/method change

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test
- Manual test (add detailed scripts or steps below)

### Side effects

<!-- REMOVE the items that are not applicable -->
- No side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- No related changes
