### PR TITLE
[fxi #275]: fix cdc hang on when send SIGSTOP to pd leader

### DIFF
--- a/cdc/cdc/capture/capture.go
+++ b/cdc/cdc/capture/capture.go
@@ -27,6 +27,7 @@ import (
 	tidbkv "github.com/pingcap/tidb/kv"
 	"github.com/tikv/client-go/v2/tikv"
 	pd "github.com/tikv/pd/client"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 	"go.etcd.io/etcd/server/v3/mvcc"
 	"go.uber.org/zap"
@@ -104,8 +105,17 @@ func (c *Capture) reset(ctx context.Context) error {
 		// It can't be handled even after it fails, so we ignore it.
 		_ = c.session.Close()
 	}
+
+	leaseID, err := c.etcdClient.Client.Grant(ctx, int64(conf.CaptureSessionTTL))
+	if err != nil {
+		return errors.Annotate(
+			cerror.WrapError(cerror.ErrNewCaptureFailed, err),
+			"grant lease")
+	}
+
 	sess, err := concurrency.NewSession(c.etcdClient.Client.Unwrap(),
-		concurrency.WithTTL(conf.CaptureSessionTTL))
+		concurrency.WithTTL(conf.CaptureSessionTTL),
+		concurrency.WithLease(leaseID.ID))
 	if err != nil {
 		return errors.Annotate(
 			cerror.WrapError(cerror.ErrNewCaptureFailed, err),
@@ -377,7 +387,8 @@ func (c *Capture) campaign(ctx cdcContext.Context) error {
 	failpoint.Inject("capture-campaign-compacted-error", func() {
 		failpoint.Return(errors.Trace(mvcc.ErrCompacted))
 	})
-	return cerror.WrapError(cerror.ErrCaptureCampaignOwner, c.election.Campaign(ctx, c.info.ID))
+	nctx := clientv3.WithRequireLeader(ctx)
+	return cerror.WrapError(cerror.ErrCaptureCampaignOwner, c.election.Campaign(nctx, c.info.ID))
 }
 
 // resign lets an owner start a new election.

--- a/cdc/pkg/version/check.go
+++ b/cdc/pkg/version/check.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -55,6 +56,10 @@ var (
 
 	// we use the minimal release version as default.
 	defaultTiKVCDCVersion *semver.Version = semver.New("1.0.0-alpha")
+)
+
+const (
+	PDRequestTimeout = 5 * time.Second
 )
 
 var versionHash = regexp.MustCompile("-[0-9]+-g[0-9a-f]{7,}(-dev)?")
@@ -104,6 +109,8 @@ func CheckPDVersion(ctx context.Context, pdAddr string, credential *security.Cre
 		return err
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, PDRequestTimeout)
+	defer cancel()
 	req, err := http.NewRequestWithContext(
 		ctx, http.MethodGet, fmt.Sprintf("%s/pd/api/v1/version", pdAddr), nil)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: zeminzhou <zhouzemin@pingcap.com>

<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?
fix cdc hang on when send SIGSTOP to pd leader
Issue Number: close #275

Problem Description: **TBD**
fix cdc hang on when send SIGSTOP to pd leader

### What is changed and how does it work?
1. Add timeout for http request  that sends pd.
2. etcd: Grant a leaseID before new seesion.
3. Add `WithRequireLeader` for context before campaign.

### Code changes

<!-- REMOVE the items that are not applicable -->
- Has exported function/method change


### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)