### PR TITLE
[to #250] cdc: remove empty value check in client-go

### DIFF
--- a/cdc/go.mod
+++ b/cdc/go.mod
@@ -225,6 +225,6 @@ replace (
 	github.com/benbjohnson/clock v1.3.0 => github.com/benbjohnson/clock v1.1.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible => github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/golang-jwt/jwt v3.2.1+incompatible => github.com/golang-jwt/jwt v3.2.0+incompatible
-	github.com/tikv/client-go/v2 v2.0.1-0.20220818084834-0d0ae0dcfb1f => github.com/pingyu/client-go/v2 v2.0.1-0.20221028021235-c7cc3f25ac91
+	github.com/tikv/client-go/v2 v2.0.1-0.20220818084834-0d0ae0dcfb1f => github.com/pingyu/client-go/v2 v2.0.1-0.20221028075800-6ec40fff4e31
 	github.com/uber-go/atomic => go.uber.org/atomic v1.4.0
 )

--- a/cdc/go.mod
+++ b/cdc/go.mod
@@ -227,3 +227,5 @@ replace (
 	github.com/golang-jwt/jwt v3.2.1+incompatible => github.com/golang-jwt/jwt v3.2.0+incompatible
 	github.com/uber-go/atomic => go.uber.org/atomic v1.4.0
 )
+
+// replace github.com/tikv/client-go/v2 v2.0.1-0.20220818084834-0d0ae0dcfb1f => github.com/pingyu/client-go/v2 v2.0.1-0.20221028021235-c7cc3f25ac91

--- a/cdc/go.mod
+++ b/cdc/go.mod
@@ -225,7 +225,6 @@ replace (
 	github.com/benbjohnson/clock v1.3.0 => github.com/benbjohnson/clock v1.1.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible => github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/golang-jwt/jwt v3.2.1+incompatible => github.com/golang-jwt/jwt v3.2.0+incompatible
+	github.com/tikv/client-go/v2 v2.0.1-0.20220818084834-0d0ae0dcfb1f => github.com/pingyu/client-go/v2 v2.0.1-0.20221028021235-c7cc3f25ac91
 	github.com/uber-go/atomic => go.uber.org/atomic v1.4.0
 )
-
-// replace github.com/tikv/client-go/v2 v2.0.1-0.20220818084834-0d0ae0dcfb1f => github.com/pingyu/client-go/v2 v2.0.1-0.20221028021235-c7cc3f25ac91

--- a/cdc/go.sum
+++ b/cdc/go.sum
@@ -868,6 +868,8 @@ github.com/pingcap/tidb/parser v0.0.0-20220824050620-75c70ecd0aeb h1:2s7VMDM/pet
 github.com/pingcap/tidb/parser v0.0.0-20220824050620-75c70ecd0aeb/go.mod h1:wjvp+T3/T9XYt0nKqGX3Kc1AKuyUcfno6LTc6b2A6ew=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
+github.com/pingyu/client-go/v2 v2.0.1-0.20221028021235-c7cc3f25ac91 h1:JMQQewk/5wvYFAeCfOT2CLCCpRe8v3B6jQVlPt0a1ZI=
+github.com/pingyu/client-go/v2 v2.0.1-0.20221028021235-c7cc3f25ac91/go.mod h1:v3DEt8LS9olI6D6El17pYBWq7B28hw3NnDFTxQHDLpY=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
@@ -1035,8 +1037,6 @@ github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
-github.com/tikv/client-go/v2 v2.0.1-0.20220818084834-0d0ae0dcfb1f h1:/nr7P8uzJQ7u3wPEBHCokrsVmuDvi/1x/zI/ydk5n8U=
-github.com/tikv/client-go/v2 v2.0.1-0.20220818084834-0d0ae0dcfb1f/go.mod h1:v3DEt8LS9olI6D6El17pYBWq7B28hw3NnDFTxQHDLpY=
 github.com/tikv/pd v1.1.0-beta.0.20220725055910-7187a7ab72db h1:0IGLATF84S3eB3iitzBEWfDmxp/v3YbYATQDUP2DNbw=
 github.com/tikv/pd v1.1.0-beta.0.20220725055910-7187a7ab72db/go.mod h1:oiKon0mls7OkA2Zuy8lg1CCvU0gdgUWCcZYkMq8IeDw=
 github.com/tikv/pd/client v0.0.0-20220725055910-7187a7ab72db h1:r1eMh9Rny3hfWuBuxOnbsCRrR4FhthiNxLQ5rAUtaww=

--- a/cdc/go.sum
+++ b/cdc/go.sum
@@ -868,8 +868,8 @@ github.com/pingcap/tidb/parser v0.0.0-20220824050620-75c70ecd0aeb h1:2s7VMDM/pet
 github.com/pingcap/tidb/parser v0.0.0-20220824050620-75c70ecd0aeb/go.mod h1:wjvp+T3/T9XYt0nKqGX3Kc1AKuyUcfno6LTc6b2A6ew=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
-github.com/pingyu/client-go/v2 v2.0.1-0.20221028021235-c7cc3f25ac91 h1:JMQQewk/5wvYFAeCfOT2CLCCpRe8v3B6jQVlPt0a1ZI=
-github.com/pingyu/client-go/v2 v2.0.1-0.20221028021235-c7cc3f25ac91/go.mod h1:v3DEt8LS9olI6D6El17pYBWq7B28hw3NnDFTxQHDLpY=
+github.com/pingyu/client-go/v2 v2.0.1-0.20221028075800-6ec40fff4e31 h1:TgDMm/47VA9hAohWmvk08gk9f63dgw8ZcbKC/5KJcjU=
+github.com/pingyu/client-go/v2 v2.0.1-0.20221028075800-6ec40fff4e31/go.mod h1:v3DEt8LS9olI6D6El17pYBWq7B28hw3NnDFTxQHDLpY=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/cdc/tests/integration_tests/http_api/util/test_case.py
+++ b/cdc/tests/integration_tests/http_api/util/test_case.py
@@ -235,7 +235,7 @@ def move_keyspan():
     assert resp.status_code == rq.codes.accepted
 
     # verfiy
-    time.sleep(5)
+    time.sleep(10)  # TODO: lower sleep duration & retry
     base_url = BASE_URL0 + "/processors"
     resp = rq.get(base_url, cert=CERT, verify=VERIFY)
     assert resp.status_code == rq.codes.ok

--- a/cdc/tests/utils/rawkv_data/gen_data.go
+++ b/cdc/tests/utils/rawkv_data/gen_data.go
@@ -31,8 +31,12 @@ import (
 
 func generateTestData(keyIndex int) (key, value0, value1 []byte) {
 	key = []byte(fmt.Sprintf("indexInfo_:_pf01_:_APD0101_:_%019d", keyIndex))
-	value0 = []byte(fmt.Sprintf("v0_%020d", keyIndex))
-	value1 = []byte(fmt.Sprintf("v1_%020d%020d", keyIndex, keyIndex))
+	if keyIndex % 1000 != 42 { // To generate test data with empty value. See https://github.com/tikv/migration/issues/250
+		value0 = []byte(fmt.Sprintf("v0_%020d", keyIndex))
+	}
+	if keyIndex % 1000 != 442 {
+		value1 = []byte(fmt.Sprintf("v1_%020d%020d", keyIndex, keyIndex))
+	}
 	return key, value0, value1
 }
 

--- a/cdc/tests/utils/rawkv_data/gen_data.go
+++ b/cdc/tests/utils/rawkv_data/gen_data.go
@@ -31,10 +31,12 @@ import (
 
 func generateTestData(keyIndex int) (key, value0, value1 []byte) {
 	key = []byte(fmt.Sprintf("indexInfo_:_pf01_:_APD0101_:_%019d", keyIndex))
-	if keyIndex%1000 != 42 { // To generate test data with empty value. See https://github.com/tikv/migration/issues/250
+	value0 = []byte{}       // Don't assign nil, which means "NotFound" in CompareAndSwap
+	if keyIndex%100 != 42 { // To generate test data with empty value. See https://github.com/tikv/migration/issues/250
 		value0 = []byte(fmt.Sprintf("v0_%020d", keyIndex))
 	}
-	if keyIndex%1000 != 442 {
+	value1 = []byte{}
+	if keyIndex%100 != 43 {
 		value1 = []byte(fmt.Sprintf("v1_%020d%020d", keyIndex, keyIndex))
 	}
 	return key, value0, value1

--- a/cdc/tests/utils/rawkv_data/gen_data.go
+++ b/cdc/tests/utils/rawkv_data/gen_data.go
@@ -31,10 +31,10 @@ import (
 
 func generateTestData(keyIndex int) (key, value0, value1 []byte) {
 	key = []byte(fmt.Sprintf("indexInfo_:_pf01_:_APD0101_:_%019d", keyIndex))
-	if keyIndex % 1000 != 42 { // To generate test data with empty value. See https://github.com/tikv/migration/issues/250
+	if keyIndex%1000 != 42 { // To generate test data with empty value. See https://github.com/tikv/migration/issues/250
 		value0 = []byte(fmt.Sprintf("v0_%020d", keyIndex))
 	}
-	if keyIndex % 1000 != 442 {
+	if keyIndex%1000 != 442 {
 		value1 = []byte(fmt.Sprintf("v1_%020d%020d", keyIndex, keyIndex))
 	}
 	return key, value0, value1


### PR DESCRIPTION
Signed-off-by: pingyu <yuping@pingcap.com>

<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #250

Problem Description: cdc: changefeed raise error "empty value is not supported"

### What is changed and how does it work?

* Remove empty value check in tikv/client-go. See https://github.com/tikv/client-go/pull/612 (It's a temporarily fix on personal fork. Will pull to master later)
* Modify integration test to generate test data with empty value
* Prolong sleep duration of "move_keyspan" test, as the original "5s" seems to be not enough. See [here](https://ci.pingcap.net/blue/organizations/jenkins/common-check/detail/common-check/108312/pipeline/).

### Code changes

<!-- REMOVE the items that are not applicable -->

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Integration test

### Side effects

<!-- REMOVE the items that are not applicable -->
- No side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- No related changes
