### PR TITLE
[to #312] Fix command name

### DIFF
--- a/cdc/pkg/cmd/cmd.go
+++ b/cdc/pkg/cmd/cmd.go
@@ -25,9 +25,9 @@ import (
 // NewCmd creates the root command.
 func NewCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "cdc",
-		Short: "CDC",
-		Long:  `Change Data Capture`,
+		Use:   "tikv-cdc",
+		Short: "TiKV CDC",
+		Long:  `TiKV Change Data Capture`,
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
 		},


### PR DESCRIPTION
Signed-off-by: Ping Yu <yuping@pingcap.com>

<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #312

Problem Description: **command name in cli help is not correct**

### What is changed and how does it work?

Change `cdc` in prompt message to `tikv-cdc`

### Code changes

<!-- REMOVE the items that are not applicable -->

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Manual test (add detailed scripts or steps below)

```bash
❯ bin/tikv-cdc --help
TiKV Change Data Capture

Usage:
  tikv-cdc [command]

Available Commands:
  cli         Manage replication task and TiKV-CDC cluster
  help        Help about any command
  server      Start a TiKV-CDC capture server
  version     Output version information

Flags:
  -h, --help   help for tikv-cdc

Use "tikv-cdc [command] --help" for more information about a command.
❯ bin/tikv-cdc cli --help
Manage replication task and TiKV-CDC cluster

Usage:
  tikv-cdc cli [flags]
  tikv-cdc cli [command]

Available Commands:
  capture     Manage capture (capture is a CDC server instance)
  changefeed  Manage changefeed (changefeed is a replication task)
  processor   Manage processor (processor is a sub replication task running on a specified capture)
  tso         Manage tso

Flags:
      --ca string          CA certificate path for TLS connection
      --cert string        Certificate path for TLS connection
  -h, --help               help for cli
  -i, --interact           Run cdc cli with readline
      --key string         Private key path for TLS connection
      --log-level string   log level (etc: debug|info|warn|error) (default "warn")
      --pd string          PD address, use ',' to separate multiple PDs (default "http://127.0.0.1:2379")

Use "tikv-cdc cli [command] --help" for more information about a command.
❯
```

### Side effects

- No side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- No related changes

### To reviewers

<!-- Please keep the following text as a reminder to PR reviewers -->
Please follow these principles to check this pull requests:

- **Concentration**. One pull request should only do one thing. No matter how small it is, the change does exactly one thing and gets it right. Don't mix other changes into it.
- **Tests**. A pull request should be test covered, whether the tests are unit tests, integration tests, or end-to-end tests. Tests should be sufficient, correct and don't slow down the CI pipeline largely.
- **Functionality**. The pull request should implement what the author intends to do and fit well in the existing code base, resolve a real problem for TiDB/TiKV users. To get the author's intention and the pull request design, you could follow the discussions in the corresponding GitHub issue or [internal.tidb.io](https://internals.tidb.io) topic.
- **Style**. Code in the pull request should follow common programming style. *(For Go, we have style checkers in CI)*. However, sometimes the existing code is inconsistent with the style guide, you should maintain consistency with the existing code or file a new issue to fix the existing code style first.
- **Documentation**. If a pull request changes how users build, test, interact with, or release code, you must check whether it also updates the related documentation such as READMEs and any generated reference docs. Similarly, if a pull request deletes or deprecates code, you must check whether or not the corresponding documentation should also be deleted.
- **Performance**. If you find the pull request may affect performance, you could ask the author to provide a benchmark result.

*(The above text mainly refers to [TiDB Development Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/review-a-pr.html#checking-pull-requests). It's also highly recommended to read about [Writing code review comments](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/review-a-pr.html#writing-code-review-comments))*
