### PR TITLE
[to #371] chore: Upgrade golangci-lint to v1.55.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,15 +49,15 @@ linters-settings:
       - name: unreachable-code
 
   depguard:
-    list-type: blacklist
-    include-go-root: false
-    packages:
-      - log
-      - github.com/juju/errors
-    packages-with-error-message:
-      # specify an error message to output when a blacklisted package is used
-      - log: "logging is allowed only by pingcap/log"
-      - github.com/juju/errors: "error handling is allowed only by pingcap/errors"
+    rules:
+      main:
+        list-mode: lax # everything is allowed unless it is denied.
+        deny:
+          - pkg: "log"
+            desc: logging is allowed only by pingcap/log
+          - pkg: "github.com/juju/errors"
+            desc: error handling is allowed only by pingcap/errors
+
   staticcheck:
     checks: ["S1002","S1004","S1007","S1009","S1010","S1012","S1019","S1020","S1021","S1024","S1030","SA2*","SA3*","SA4009","SA5*","SA6000","SA6001","SA6005", "-SA2002"]
   stylecheck:

--- a/br/Makefile
+++ b/br/Makefile
@@ -86,7 +86,7 @@ failpoint/disable: tools/bin/failpoint-ctl
 	find `pwd` -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl disable
 
 tools/bin/golangci-lint:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./tools/bin v1.52.2
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./tools/bin v1.55.2
 
 tools/bin/failpoint-ctl: tools/check/go.mod
 	cd tools/check && $(GO) build -o ../bin/failpoint-ctl github.com/pingcap/failpoint/failpoint-ctl

--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -250,7 +250,9 @@ func (bc *Client) BackupRanges(
 	progressCallBack func(ProgressUnit),
 ) error {
 	init := time.Now()
-	defer log.Info("Backup Ranges", zap.Duration("take", time.Since(init)))
+	defer func() {
+		log.Info("Backup Ranges", zap.Duration("take", time.Since(init)))
+	}()
 
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("Client.BackupRanges", opentracing.ChildOf(span.Context()))

--- a/br/pkg/backup/client_test.go
+++ b/br/pkg/backup/client_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/jarcoal/httpmock"
-	. "github.com/pingcap/check"
+	. "github.com/pingcap/check" // nolint:revive
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"

--- a/br/pkg/storage/s3_test.go
+++ b/br/pkg/storage/s3_test.go
@@ -21,7 +21,7 @@ import (
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/migration/br/pkg/mock"
-	. "github.com/tikv/migration/br/pkg/storage"
+	. "github.com/tikv/migration/br/pkg/storage" // nolint:revive
 )
 
 type s3Suite struct {

--- a/cdc/Makefile
+++ b/cdc/Makefile
@@ -202,7 +202,7 @@ tools/bin/goveralls: tools/check/go.mod
 	cd tools/check && $(GO) build -mod=mod -o ../bin/goveralls github.com/mattn/goveralls
 
 tools/bin/golangci-lint: tools/check/go.mod
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b tools/bin v1.51.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b tools/bin v1.55.2
 
 tools/bin/mockgen: tools/check/go.mod
 	cd tools/check && $(GO) build -mod=mod -o ../bin/mockgen github.com/golang/mock/mockgen

--- a/cdc/cdc/model/kv.go
+++ b/cdc/cdc/model/kv.go
@@ -54,9 +54,8 @@ func (e *RegionFeedEvent) GetValue() interface{} {
 		return e.Val
 	} else if e.Resolved != nil {
 		return e.Resolved
-	} else {
-		return nil
 	}
+	return nil
 }
 
 // ResolvedSpan guarantees all the KV value event

--- a/cdc/pkg/fsutil/filelock.go
+++ b/cdc/pkg/fsutil/filelock.go
@@ -79,7 +79,6 @@ func (fl *FileLock) IsLocked() (bool, error) {
 		return true, nil
 	} else if err != nil {
 		return false, errors.Trace(err)
-	} else {
-		return false, nil
 	}
+	return false, nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: ref #371 

Problem Description: **TBD**

### What is changed and how does it work?

- Upgrade golangci-lint to v1.55.2 to address the lint error for #372, see https://github.com/tikv/migration/actions/runs/7069331510/job/19245442484

```
cdc/processor/processor_test.go:594:93: missing type in composite literal (typecheck)
        c.Assert(p.changefeed.Workloads[p.captureInfo.ID], check.DeepEquals, model.TaskWorkload{1: {Workload: 1}, 2: {Workload: 1}})
                                                                                                   ^
pkg/cmd/cli/cli_changefeed_helper.go:119:2: forceRemoveOpt declared and not used (typecheck)
        forceRemoveOpt := "false"
        ^
pkg/orchestrator/reactor_state_test.go:99:51: missing type in composite literal (typecheck)
                                        "6bbc01c8-0605-4f86-a0f9-b3119109b225": {45: {Workload: 1}},
                                                                                     ^
pkg/orchestrator/reactor_state_test.go:158:51: missing type in composite literal (typecheck)
                                        "6bbc01c8-0605-4f86-a0f9-b3119109b225": {45: {Workload: 1}},
                                                                                     ^
pkg/pipeline/pipeline_test.go:235:7: ctx.Throw undefined (type NodeContext has no field or method Throw) (typecheck)
                ctx.Throw(errors.Errorf("error node throw an error, index: %d", n.index))
                    ^
pkg/util/ctx_test.go:21:2: "github.com/tikv/client-go/v2/tikv" imported and not used (typecheck)
        "github.com/tikv/client-go/v2/tikv"
        ^
../../../opt/go1.21.0/src/slices/sort.go:67:7: undefined: min (typecheck)
                m = min(m, x[i])
                    ^
../../../opt/go1.21.0/src/slices/sort.go:97:7: undefined: max (typecheck)
                m = max(m, x[i])
                    ^
../../../go/pkg/mod/github.com/pingcap/tidb/pkg/parser@v0.0.0-20231124053542-069631e2ecfe/parser.go:13476:10: previous case (typecheck)
                                case *ast.ColumnDef:
                                     ^
../../../go/pkg/mod/github.com/pingcap/tidb/pkg/parser@v0.0.0-20231124053542-069631e2ecfe/parser.go:19679:9: previous case (typecheck)
                        case *ast.SelectStmt:
                             ^
../../../go/pkg/mod/github.com/pingcap/tidb/pkg/parser@v0.0.0-20231124053542-069631e2ecfe/parser.go:19967:9: previous case (typecheck)
                        case *ast.SelectStmt:
                             ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/util/memory/meminfo.go:124:9: undefined: min (typecheck)
        memo = min(v.Total, memo)
               ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/util/memory/meminfo.go:143:9: undefined: min (typecheck)
        memo = min(v.Used, memo)
               ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/util/chunk/row_container.go:337:17: c.actionSpill.SetFinished undefined (type *SpillDiskAction has no field or method SetFinished) (typecheck)
                c.actionSpill.SetFinished()
                              ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/util/chunk/row_container.go:460:19: a.GetFallback undefined (type *baseSpillDiskAction has no field or method GetFallback) (typecheck)
        if fallback := a.GetFallback(); fallback != nil {
                         ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/expression/builtin_other_vec_generated.go:163:3: collator declared and not used (typecheck)
                collator := collate.GetCollator(b.collation)
                ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/expression/builtin_other_vec_generated.go:169:4: arg0 declared and not used (typecheck)
                        arg0 := buf0.GetString(i)
                        ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/expression/builtin_other_vec_generated.go:340:4: arg0 declared and not used (typecheck)
                        arg0 := args0[i]
                        ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/expression/extension.go:160:7: b.EvalTp undefined (type *extensionFuncSig has no field or method EvalTp) (typecheck)
        if b.EvalTp == types.ETString {
             ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/expression/extension.go:161:12: b.EvalStringFunc undefined (type *extensionFuncSig has no field or method EvalStringFunc) (typecheck)
                return b.EvalStringFunc(b, row)
                         ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/expression/extension.go:167:7: b.EvalTp undefined (type *extensionFuncSig has no field or method EvalTp) (typecheck)
        if b.EvalTp == types.ETInt {
             ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/expression/extension.go:168:12: b.EvalIntFunc undefined (type *extensionFuncSig has no field or method EvalIntFunc) (typecheck)
                return b.EvalIntFunc(b, row)
                         ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/expression/builtin.go:38:2: "github.com/pingcap/tidb/pkg/parser/opcode" imported and not used (typecheck)
        "github.com/pingcap/tidb/pkg/parser/opcode"
        ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/sessionctx/variable/session.go:567:9: cannot use &temporaryTableData{…} (value of type *temporaryTableData) as TemporaryTableData value in return statement: *temporaryTableData does not implement TemporaryTableData (missing method Cleanup) (typecheck)
        return &temporaryTableData{
               ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:84:11: n.Kind undefined (type *ValueExpr has no field or method Kind) (typecheck)
        switch n.Kind() {
                 ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:88:8: n.Type undefined (type *ValueExpr has no field or method Type) (typecheck)
                if n.Type.GetFlag()&mysql.IsBooleanFlag != 0 {
                     ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:89:9: n.GetInt64 undefined (type *ValueExpr has no field or method GetInt64) (typecheck)
                        if n.GetInt64() > 0 {
                             ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:95:39: n.GetInt64 undefined (type *ValueExpr has no field or method GetInt64) (typecheck)
                        ctx.WritePlain(strconv.FormatInt(n.GetInt64(), 10))
                                                           ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:98:39: n.GetUint64 undefined (type *ValueExpr has no field or method GetUint64) (typecheck)
                ctx.WritePlain(strconv.FormatUint(n.GetUint64(), 10))
                                                    ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:100:40: n.GetFloat64 undefined (type *ValueExpr has no field or method GetFloat64) (typecheck)
                ctx.WritePlain(strconv.FormatFloat(n.GetFloat64(), 'e', -1, 32))
                                                     ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:102:40: n.GetFloat64 undefined (type *ValueExpr has no field or method GetFloat64) (typecheck)
                ctx.WritePlain(strconv.FormatFloat(n.GetFloat64(), 'e', -1, 64))
                                                     ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:106:8: n.Type undefined (type *ValueExpr has no field or method Type) (typecheck)
                if n.Type.GetCharset() != "" &&
                     ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:108:54: n.Type undefined (type *ValueExpr has no field or method Type) (typecheck)
                        (!ctx.Flags.HasStringWithoutDefaultCharset() || n.Type.GetCharset() != mysql.DefaultCharset) {
                                                                          ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:113:40: n.GetString undefined (type *ValueExpr has no field or method GetString) (typecheck)
                ctx.WriteString(strings.ReplaceAll(n.GetString(), "\\", "\\\\"))
                                                     ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:115:21: n.GetString undefined (type *ValueExpr has no field or method GetString) (typecheck)
                ctx.WriteString(n.GetString())
                                  ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:117:20: n.GetMysqlDecimal undefined (type *ValueExpr has no field or method GetMysqlDecimal) (typecheck)
                ctx.WritePlain(n.GetMysqlDecimal().String())
                                 ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:120:31: n.GetBytes undefined (type *ValueExpr has no field or method GetBytes) (typecheck)
                        ctx.WritePlainf("x'%x'", n.GetBytes())
                                                   ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:122:21: n.GetBinaryLiteral undefined (type *ValueExpr has no field or method GetBinaryLiteral) (typecheck)
                        ctx.WritePlain(n.GetBinaryLiteral().ToBitLiteralString(true))
                                         ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:125:29: n.GetMysqlDuration undefined (type *ValueExpr has no field or method GetMysqlDuration) (typecheck)
                ctx.WritePlainf("'%s'", n.GetMysqlDuration())
                                          ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:127:29: n.GetMysqlTime undefined (type *ValueExpr has no field or method GetMysqlTime) (typecheck)
                ctx.WritePlainf("'%s'", n.GetMysqlTime())
                                          ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:142:11: n.GetString undefined (type *ValueExpr has no field or method GetString) (typecheck)
        return n.GetString()
                 ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:148:11: n.Kind undefined (type *ValueExpr has no field or method Kind) (typecheck)
        switch n.Kind() {
                 ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:153:9: n.GetInt64 undefined (type *ValueExpr has no field or method GetInt64) (typecheck)
                        if n.GetInt64() > 0 {
                             ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:162:28: n.GetUint64 undefined (type *ValueExpr has no field or method GetUint64) (typecheck)
                s = strconv.FormatUint(n.GetUint64(), 10)
                                         ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:164:29: n.GetFloat64 undefined (type *ValueExpr has no field or method GetFloat64) (typecheck)
                s = strconv.FormatFloat(n.GetFloat64(), 'e', -1, 32)
                                          ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:172:9: n.GetMysqlDecimal undefined (type *ValueExpr has no field or method GetMysqlDecimal) (typecheck)
                s = n.GetMysqlDecimal().String()
                      ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:175:31: n.GetBytes undefined (type *ValueExpr has no field or method GetBytes) (typecheck)
                        s = fmt.Sprintf("x'%x'", n.GetBytes())
                                                   ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:177:10: n.GetBinaryLiteral undefined (type *ValueExpr has no field or method GetBinaryLiteral) (typecheck)
                        s = n.GetBinaryLiteral().ToBitLiteralString(true)
                              ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:210:39: ve.Type undefined (type *ValueExpr has no field or method Type) (typecheck)
        types.DefaultTypeForValue(value, &ve.Type, charset, collate)
                                             ^
../../../go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20231124053542-069631e2ecfe/pkg/types/parser_driver/value_expr.go:211:31: ve.Type undefined (type *ValueExpr has no field or method Type) (typecheck)
        ve.Datum.SetValue(value, &ve.Type)
                                     ^
make: *** [Makefile:151: check-static] Error 1
```

### Code changes

<!-- REMOVE the items that are not applicable -->

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test
- Integration test

### Side effects

<!-- REMOVE the items that are not applicable -->
- No side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
- No related changes

### To reviewers

<!-- Please keep the following text as a reminder to PR reviewers -->
Please follow these principles to check this pull requests:

- **Concentration**. One pull request should only do one thing. No matter how small it is, the change does exactly one thing and gets it right. Don't mix other changes into it.
- **Tests**. A pull request should be test covered, whether the tests are unit tests, integration tests, or end-to-end tests. Tests should be sufficient, correct and don't slow down the CI pipeline largely.
- **Functionality**. The pull request should implement what the author intends to do and fit well in the existing code base, resolve a real problem for TiDB/TiKV users. To get the author's intention and the pull request design, you could follow the discussions in the corresponding GitHub issue or [internal.tidb.io](https://internals.tidb.io) topic.
- **Style**. Code in the pull request should follow common programming style. *(For Go, we have style checkers in CI)*. However, sometimes the existing code is inconsistent with the style guide, you should maintain consistency with the existing code or file a new issue to fix the existing code style first.
- **Documentation**. If a pull request changes how users build, test, interact with, or release code, you must check whether it also updates the related documentation such as READMEs and any generated reference docs. Similarly, if a pull request deletes or deprecates code, you must check whether or not the corresponding documentation should also be deleted.
- **Performance**. If you find the pull request may affect performance, you could ask the author to provide a benchmark result.

*(The above text mainly refers to [TiDB Development Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/review-a-pr.html#checking-pull-requests). It's also highly recommended to read about [Writing code review comments](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/review-a-pr.html#writing-code-review-comments))*
