### PR TITLE
[close #407] Fix arm64 build

### DIFF
--- a/.github/workflows/release_version.yml
+++ b/.github/workflows/release_version.yml
@@ -74,8 +74,8 @@ jobs:
         run: |
           export GOPATH=${GITHUB_WORKSPACE}/go
           export PATH=$PATH:$GOPATH/bin
-          export GOOS=${{ matrix.os }}
-          export GOARCH=${{ matrix.arch }}
+          export TARGET_OS=${{ matrix.os }}
+          export TARGET_ARCH=${{ matrix.arch }}
           if [ ! -z ${{ steps.check_staging.outputs.STAGING }} ]; then
             export REL_VER=${{ steps.check_staging.outputs.STAGING }}+staging
           else

--- a/br/Makefile
+++ b/br/Makefile
@@ -95,7 +95,7 @@ build:
 	CGO_ENABLED=1 $(GO) build -tags codes -gcflags "all=-N -l" -ldflags '$(LDFLAGS)' -o $(BR_BIN_PATH) cmd/br/*.go
 
 release:
-	CGO_ENABLED=1 $(GO) build -tags codes -ldflags '$(LDFLAGS)' -o $(BR_BIN_PATH) cmd/br/*.go
+	CGO_ENABLED=1 GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) $(GO) build -tags codes -ldflags '$(LDFLAGS)' -o $(BR_BIN_PATH) cmd/br/*.go
 
 build/rawkv-integration-test:
 	cd tests/rawkv && $(GO) build -mod=mod -o ../../bin/rawkv_test *.go

--- a/cdc/Makefile
+++ b/cdc/Makefile
@@ -21,7 +21,7 @@ endif
 
 BUILD_FLAG := -buildvcs=false
 
-GOBUILD  := CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build $(BUILD_FLAG) -trimpath $(GOVENDORFLAG)
+GOBUILD  := CGO_ENABLED=0 GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) $(GO) build $(BUILD_FLAG) -trimpath $(GOVENDORFLAG)
 GOBUILD_DEBUG  := CGO_ENABLED=0 $(GO) build $(BUILD_FLAG) -gcflags "all=-N -l" $(GOVENDORFLAG)
 GOBUILDNOVENDOR  := CGO_ENABLED=0 $(GO) build $(BUILD_FLAG) -trimpath
 GOTEST   := CGO_ENABLED=1 $(GO) test -p $(P) --race
@@ -45,7 +45,7 @@ FAILPOINT_DISABLE := $$(echo $(FAILPOINT_DIR) | xargs $(FAILPOINT) disable >/dev
 
 RELEASE_VERSION ?=
 ifeq ($(RELEASE_VERSION),)
-	RELEASE_VERSION := v1.2-master
+	RELEASE_VERSION := v1.3-master
 	release_version_regex := ^cdc-v[0-9]\..*$$
 	release_branch_regex := "^cdc-[0-9]\.[0-9].*$$|^HEAD$$|^.*/*tags/cdc-v[0-9]\.[0-9]\..*$$"
 	ifneq ($(shell git rev-parse --abbrev-ref HEAD | egrep $(release_branch_regex)),)


### PR DESCRIPTION
<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #407

Problem Description: **ci: Release arm64 artifact failed type/bug**

### What is changed and how does it work?

- Change env var `GOARCH` to `TARGET_ARCH`, then tools will be built for current arch.

### Code changes

<!-- REMOVE the items that are not applicable -->

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Manual test (add detailed scripts or steps below)

```
❯ cd cdc
❯ make release
go generate
CGO_ENABLED=0 GOOS= GOARCH= GO111MODULE=on go build -buildvcs=false -trimpath  -ldflags '-X "github.com/tikv/migration/cdc/pkg/version.ReleaseVersion=v1.2-master-dirty" -X "github.com/tikv/migration/cdc/pkg/version.BuildTS=2024-06-16 13:27:51" -X "github.com/tikv/migration/cdc/pkg/version.GitHash=db0ae72b17d7f9b888b05745d4582cb11f345cc0" -X "github.com/tikv/migration/cdc/pkg/version.GitBranch=main" -X "github.com/tikv/migration/cdc/pkg/version.GoVersion=go version go1.21.0 linux/amd64"' -o bin/tikv-cdc ./cmd/cdc/main.go
❯ TARGET_OS=linux TARGET_ARCH=arm64 make release
go generate
CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GO111MODULE=on go build -buildvcs=false -trimpath  -ldflags '-X "github.com/tikv/migration/cdc/pkg/version.ReleaseVersion=v1.2-master-dirty" -X "github.com/tikv/migration/cdc/pkg/version.BuildTS=2024-06-16 13:29:27" -X "github.com/tikv/migration/cdc/pkg/version.GitHash=db0ae72b17d7f9b888b05745d4582cb11f345cc0" -X "github.com/tikv/migration/cdc/pkg/version.GitBranch=main" -X "github.com/tikv/migration/cdc/pkg/version.GoVersion=go version go1.21.0 linux/amd64"' -o bin/tikv-cdc ./cmd/cdc/main.go
❯ file bin/tikv-cdc
bin/tikv-cdc: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=gMfXoVB1YNnT1XO5vVG4/JnB2x_wNvDq-J3ExNgLs/8C2OF2OuqYMYip3-Li18/1FW1cwpC4nPfTRMcdEAk, with debug_info, not stripped
❯ TARGET_OS=linux TARGET_ARCH=amd64 make release
go generate
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -buildvcs=false -trimpath  -ldflags '-X "github.com/tikv/migration/cdc/pkg/version.ReleaseVersion=v1.3-master-dirty" -X "github.com/tikv/migration/cdc/pkg/version.BuildTS=2024-06-16 13:30:21" -X "github.com/tikv/migration/cdc/pkg/version.GitHash=db0ae72b17d7f9b888b05745d4582cb11f345cc0" -X "github.com/tikv/migration/cdc/pkg/version.GitBranch=main" -X "github.com/tikv/migration/cdc/pkg/version.GoVersion=go version go1.21.0 linux/amd64"' -o bin/tikv-cdc ./cmd/cdc/main.go
❯ file bin/tikv-cdc
bin/tikv-cdc: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=LG1_qxdPIlQfreu95e4J/jLJ05r-yHZyYag82OoT3/5p2WSfvir6H8s4CkdB_8/n20WoMJb17MzoaeZcsWW, with debug_info, not stripped
```

Make release for `arm64` of `tikv-br` failed, and will be fixed in another PR.

```
❯ make release
CGO_ENABLED=1 GOOS= GOARCH= GO111MODULE=on go build -tags codes -ldflags '-X "github.com/tikv/migration/br/pkg/version/build.ReleaseVersion=cdc-v1.3.0-beta-dirty" -X "github.com/tikv/migration/br/pkg/version/build.BuildTS=2024-06-16 13:30:59" -X "github.com/tikv/migration/br/pkg/version/build.GitHash=db0ae72b17d7f9b888b05745d4582cb11f345cc0" -X "github.com/tikv/migration/br/pkg/version/build.GitBranch=main"' -o bin/tikv-br cmd/br/*.go
❯ TARGET_OS=linux TARGET_ARCH=amd64 make release
CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -tags codes -ldflags '-X "github.com/tikv/migration/br/pkg/version/build.ReleaseVersion=cdc-v1.3.0-beta-dirty" -X "github.com/tikv/migration/br/pkg/version/build.BuildTS=2024-06-16 13:31:21" -X "github.com/tikv/migration/br/pkg/version/build.GitHash=db0ae72b17d7f9b888b05745d4582cb11f345cc0" -X "github.com/tikv/migration/br/pkg/version/build.GitBranch=main"' -o bin/tikv-br cmd/br/*.go
❯ file bin/tikv-br
bin/tikv-br: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, Go BuildID=k5UYGU4xm_Sulp9Xxh2w/5AyaDca1I_G2ylT647Tr/elpNLRWa7zRzxf4MXjqq/WfB1swD1DsC5PxkIYgEZ, with debug_info, not stripped
❯ TARGET_OS=linux TARGET_ARCH=arm64 make release
CGO_ENABLED=1 GOOS=linux GOARCH=arm64 GO111MODULE=on go build -tags codes -ldflags '-X "github.com/tikv/migration/br/pkg/version/build.ReleaseVersion=cdc-v1.3.0-beta-dirty" -X "github.com/tikv/migration/br/pkg/version/build.BuildTS=2024-06-16 13:31:34" -X "github.com/tikv/migration/br/pkg/version/build.GitHash=db0ae72b17d7f9b888b05745d4582cb11f345cc0" -X "github.com/tikv/migration/br/pkg/version/build.GitBranch=main"' -o bin/tikv-br cmd/br/*.go
# runtime/cgo
gcc_arm64.S: Assembler messages:
gcc_arm64.S:30: Error: no such instruction: `stp x29,x30,[sp,'
gcc_arm64.S:34: Error: too many memory references for `mov'
gcc_arm64.S:36: Error: no such instruction: `stp x19,x20,[sp,'
gcc_arm64.S:39: Error: no such instruction: `stp x21,x22,[sp,'
gcc_arm64.S:42: Error: no such instruction: `stp x23,x24,[sp,'
gcc_arm64.S:45: Error: no such instruction: `stp x25,x26,[sp,'
gcc_arm64.S:48: Error: no such instruction: `stp x27,x28,[sp,'
gcc_arm64.S:52: Error: too many memory references for `mov'
gcc_arm64.S:53: Error: too many memory references for `mov'
gcc_arm64.S:54: Error: too many memory references for `mov'
gcc_arm64.S:56: Error: no such instruction: `blr x20'
gcc_arm64.S:57: Error: no such instruction: `blr x19'
gcc_arm64.S:59: Error: no such instruction: `ldp x27,x28,[sp,'
gcc_arm64.S:62: Error: no such instruction: `ldp x25,x26,[sp,'
gcc_arm64.S:65: Error: no such instruction: `ldp x23,x24,[sp,'
gcc_arm64.S:68: Error: no such instruction: `ldp x21,x22,[sp,'
gcc_arm64.S:71: Error: no such instruction: `ldp x19,x20,[sp,'
gcc_arm64.S:74: Error: no such instruction: `ldp x29,x30,[sp],'
make: *** [Makefile:98: release] Error 1
```

### Side effects

<!-- REMOVE the items that are not applicable -->
- No side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- No related changes

### To reviewers

<!-- Please keep the following text as a reminder to PR reviewers -->
Please follow these principles to check this pull requests:

- **Concentration**. One pull request should only do one thing. No matter how small it is, the change does exactly one thing and gets it right. Don't mix other changes into it.
- **Tests**. A pull request should be test covered, whether the tests are unit tests, integration tests, or end-to-end tests. Tests should be sufficient, correct and don't slow down the CI pipeline largely.
- **Functionality**. The pull request should implement what the author intends to do and fit well in the existing code base, resolve a real problem for TiDB/TiKV users. To get the author's intention and the pull request design, you could follow the discussions in the corresponding GitHub issue or [internal.tidb.io](https://internals.tidb.io) topic.
- **Style**. Code in the pull request should follow common programming style. *(For Go, we have style checkers in CI)*. However, sometimes the existing code is inconsistent with the style guide, you should maintain consistency with the existing code or file a new issue to fix the existing code style first.
- **Documentation**. If a pull request changes how users build, test, interact with, or release code, you must check whether it also updates the related documentation such as READMEs and any generated reference docs. Similarly, if a pull request deletes or deprecates code, you must check whether or not the corresponding documentation should also be deleted.
- **Performance**. If you find the pull request may affect performance, you could ask the author to provide a benchmark result.

*(The above text mainly refers to [TiDB Development Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/review-a-pr.html#checking-pull-requests). It's also highly recommended to read about [Writing code review comments](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/review-a-pr.html#writing-code-review-comments))*
