### PR TITLE
[close #421] br: Split for smaller batch of keys

### DIFF
--- a/.github/config/br_pd.toml
+++ b/.github/config/br_pd.toml
@@ -2,3 +2,8 @@
 [replication]
 enable-placement-rules = true
 max-replicas = 1
+
+[schedule]
+max-merge-region-size = 2
+max-merge-region-keys = 40000
+split-merge-interval = "10s"

--- a/.github/config/br_rawkv.toml
+++ b/.github/config/br_rawkv.toml
@@ -7,6 +7,12 @@ pd-heartbeat-tick-interval = "2s"
 pd-store-heartbeat-tick-interval = "5s"
 split-region-check-tick-interval = "1s"
 
+# 10000000 keys & ~480MB data size in integration tests
+[coprocessor]
+region-split-size = "10MiB"
+region-split-keys = 200000
+batch-split-limit = 100
+
 [rocksdb]
 max-open-files = 10000
 
@@ -14,4 +20,5 @@ max-open-files = 10000
 max-open-files = 10000
 
 [storage]
+reserve-space = "0MiB"
 enable-ttl = true

--- a/br/Makefile
+++ b/br/Makefile
@@ -24,17 +24,18 @@ PACKAGES    := go list ./...
 DIRECTORIES := $(PACKAGES) | sed 's|github.com/tikv/migration/br/||'
 
 # build & test
-BR_BIN_PATH     ?= bin/tikv-br
-TEST_BIN_PATH   ?= bin/tikv-br.test
-COVERAGE_DIR    ?= build
-TEST_PARALLEL   ?= 8
-PD_ADDR         ?= 127.0.0.1:2379
-BR_LOCAL_STORE  ?= /tmp/backup_restore_test
-API_VERSION     ?= 1
-CLUSTER_VERSION ?= nightly
-TLS_CA          ?= 
-TLS_CERT        ?= 
-TLS_KEY         ?= 
+BR_BIN_PATH           ?= bin/tikv-br
+TEST_BIN_PATH         ?= bin/tikv-br.test
+COVERAGE_DIR          ?= build
+TEST_PARALLEL         ?= 8
+PD_ADDR               ?= 127.0.0.1:2379
+SPLIT_REGION_MAX_KEYS ?= 4
+BR_LOCAL_STORE        ?= /tmp/backup_restore_test
+API_VERSION           ?= 1
+CLUSTER_VERSION       ?= nightly
+TLS_CA                ?= 
+TLS_CERT              ?= 
+TLS_KEY               ?= 
 
 LDFLAGS += -X "github.com/tikv/migration/br/pkg/version/build.ReleaseVersion=$(shell git describe --tags --dirty --always)"
 LDFLAGS += -X "github.com/tikv/migration/br/pkg/version/build.BuildTS=$(shell date -u '+%Y-%m-%d %H:%M:%S')"
@@ -71,6 +72,7 @@ test/integration: build/br-test build/rawkv-integration-test
 	mkdir -p $(COVERAGE_DIR)
 	./bin/rawkv_test --pd=${PD_ADDR} \
 		--br='${TEST_BIN_PATH}' \
+		--split-region-max-keys=${SPLIT_REGION_MAX_KEYS} \
 		--br-storage=${BR_LOCAL_STORE} \
 		--api-version=${API_VERSION} \
 		--cluster-version=${CLUSTER_VERSION} \

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -44,6 +44,7 @@ type Client struct {
 	workerPool    *utils.WorkerPool
 	tlsConf       *tls.Config
 	keepaliveConf keepalive.ClientParameters
+	spliterConf   SpliterConfig
 
 	backupMeta    *backuppb.BackupMeta
 	dstAPIVersion kvrpcpb.APIVersion
@@ -64,6 +65,7 @@ func NewRestoreClient(
 	pdClient pd.Client,
 	tlsConf *tls.Config,
 	keepaliveConf keepalive.ClientParameters,
+	spliterConf SpliterConfig,
 	isRawKv bool,
 ) (*Client, error) {
 	apiVerion, err := conn.GetTiKVApiVersion(context.Background(), pdClient, tlsConf)
@@ -72,9 +74,10 @@ func NewRestoreClient(
 	}
 	return &Client{
 		pdClient:      pdClient,
-		toolClient:    NewSplitClient(pdClient, tlsConf, isRawKv),
+		toolClient:    NewSplitClient(pdClient, tlsConf, spliterConf, isRawKv),
 		tlsConf:       tlsConf,
 		keepaliveConf: keepaliveConf,
+		spliterConf:   spliterConf,
 		switchCh:      make(chan struct{}),
 		dstAPIVersion: apiVerion,
 	}, nil
@@ -132,7 +135,7 @@ func (rc *Client) InitBackupMeta(
 	}
 	rc.backupMeta = backupMeta
 
-	metaClient := NewSplitClient(rc.pdClient, rc.tlsConf, rc.backupMeta.IsRawKv)
+	metaClient := NewSplitClient(rc.pdClient, rc.tlsConf, rc.spliterConf, rc.backupMeta.IsRawKv)
 	importCli := NewImportClient(metaClient, rc.tlsConf, rc.keepaliveConf)
 	rc.fileImporter = NewFileImporter(metaClient, importCli, backend, rc.backupMeta.IsRawKv,
 		rc.backupMeta.ApiVersion)

--- a/br/pkg/restore/client_test.go
+++ b/br/pkg/restore/client_test.go
@@ -23,6 +23,11 @@ var defaultKeepaliveCfg = keepalive.ClientParameters{
 	Timeout: 10 * time.Second,
 }
 
+var defaultSpliterCfg = SpliterConfig{
+	GRPCMaxRecvMsgSize: 1024 * 1024,
+	SplitRegionMaxKeys: 16,
+}
+
 type fakePDClient struct {
 	pd.Client
 	stores []*metapb.Store
@@ -106,7 +111,7 @@ func TestSetSpeedLimit(t *testing.T) {
 	// 1. The cost of concurrent communication is expected to be less than the cost of serial communication.
 	client, err := NewRestoreClient(fakePDClient{
 		stores: mockStores,
-	}, nil, defaultKeepaliveCfg, true)
+	}, nil, defaultKeepaliveCfg, defaultSpliterCfg, true)
 	require.NoError(t, err)
 	client.fileImporter = NewFileImporter(nil, FakeImporterClient{}, nil, true, kvrpcpb.APIVersion_V2)
 	ctx := context.Background()

--- a/br/pkg/restore/split_client.go
+++ b/br/pkg/restore/split_client.go
@@ -66,10 +66,11 @@ type SplitClient interface {
 
 // pdClient is a wrapper of pd client, can be used by RegionSplitter.
 type pdClient struct {
-	mu         sync.Mutex
-	client     pd.Client
-	tlsConf    *tls.Config
-	storeCache map[uint64]*metapb.Store
+	mu          sync.Mutex
+	client      pd.Client
+	tlsConf     *tls.Config
+	spliterConf SpliterConfig
+	storeCache  map[uint64]*metapb.Store
 
 	// FIXME when config changed during the lifetime of pdClient,
 	// 	this may mislead the scatter.
@@ -80,12 +81,13 @@ type pdClient struct {
 }
 
 // NewSplitClient returns a client used by RegionSplitter.
-func NewSplitClient(client pd.Client, tlsConf *tls.Config, isRawKv bool) SplitClient {
+func NewSplitClient(client pd.Client, tlsConf *tls.Config, spliterConf SpliterConfig, isRawKv bool) SplitClient {
 	cli := &pdClient{
-		client:     client,
-		tlsConf:    tlsConf,
-		storeCache: make(map[uint64]*metapb.Store),
-		isRawKv:    isRawKv,
+		client:      client,
+		tlsConf:     tlsConf,
+		spliterConf: spliterConf,
+		storeCache:  make(map[uint64]*metapb.Store),
+		isRawKv:     isRawKv,
 	}
 	return cli
 }
@@ -181,7 +183,12 @@ func (c *pdClient) SplitRegion(ctx context.Context, regionInfo *RegionInfo, key 
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	conn, err := grpc.Dial(store.GetAddress(), grpc.WithInsecure())
+	opt := grpc.WithInsecure()
+	if c.tlsConf != nil {
+		opt = grpc.WithTransportCredentials(credentials.NewTLS(c.tlsConf))
+	}
+	conn, err := grpc.Dial(store.GetAddress(), opt,
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(c.spliterConf.GRPCMaxRecvMsgSize)))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -305,7 +312,8 @@ func (c *pdClient) sendSplitRegionRequest(
 		if c.tlsConf != nil {
 			opt = grpc.WithTransportCredentials(credentials.NewTLS(c.tlsConf))
 		}
-		conn, err := grpc.Dial(store.GetAddress(), opt)
+		conn, err := grpc.Dial(store.GetAddress(), opt,
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(c.spliterConf.GRPCMaxRecvMsgSize)))
 		if err != nil {
 			return nil, multierr.Append(splitErrors, err)
 		}

--- a/br/pkg/restore/split_test.go
+++ b/br/pkg/restore/split_test.go
@@ -275,7 +275,7 @@ func ScatterFinishInTimeImpl(t *testing.T, needEncodeKey bool) {
 	client := initTestClient()
 	ranges := initRanges()
 	rewriteRules := initRewriteRules()
-	regionSplitter := NewRegionSplitter(client)
+	regionSplitter := NewRegionSplitter(client, defaultSpliterCfg)
 
 	ctx := context.Background()
 	err := regionSplitter.Split(ctx, ranges, rewriteRules, needEncodeKey, func(key [][]byte) {}) // TODO: add test case for "isRawKV=true"
@@ -335,7 +335,7 @@ func TestSplitAndScatter(t *testing.T) {
 func runTestSplitAndScatterWith(t *testing.T, client *TestClient, needEncodeKey bool) {
 	ranges := initRanges()
 	rewriteRules := initRewriteRules()
-	regionSplitter := NewRegionSplitter(client)
+	regionSplitter := NewRegionSplitter(client, defaultSpliterCfg)
 
 	ctx := context.Background()
 	err := regionSplitter.Split(ctx, ranges, rewriteRules, needEncodeKey, func(key [][]byte) {}) // TODO: add test case for "isRawKV=true"

--- a/br/pkg/restore/util.go
+++ b/br/pkg/restore/util.go
@@ -109,13 +109,14 @@ func matchOldPrefix(key []byte, rewriteRules *RewriteRules) *import_sstpb.Rewrit
 func SplitRanges(
 	ctx context.Context,
 	client *Client,
+	spliterConf SpliterConfig,
 	ranges []rtree.Range,
 	rewriteRules *RewriteRules,
 	updateCh glue.Progress,
 	isRawKv bool,
 	needEncodeKey bool,
 ) error {
-	splitter := NewRegionSplitter(NewSplitClient(client.GetPDClient(), client.GetTLSConfig(), isRawKv))
+	splitter := NewRegionSplitter(NewSplitClient(client.GetPDClient(), client.GetTLSConfig(), spliterConf, isRawKv), spliterConf)
 
 	return splitter.Split(ctx, ranges, rewriteRules, needEncodeKey, func(keys [][]byte) {
 		updateCh.Inc()

--- a/br/pkg/task/common.go
+++ b/br/pkg/task/common.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tikv/migration/br/pkg/feature"
 	"github.com/tikv/migration/br/pkg/glue"
 	"github.com/tikv/migration/br/pkg/metautil"
+	"github.com/tikv/migration/br/pkg/restore"
 	"github.com/tikv/migration/br/pkg/storage"
 	"github.com/tikv/migration/br/pkg/utils"
 	pd "github.com/tikv/pd/client"
@@ -56,14 +57,19 @@ const (
 	flagGrpcKeepaliveTime = "grpc-keepalive-time"
 	// flagGrpcKeepaliveTimeout is the max time a grpc conn can keep idel before killed.
 	flagGrpcKeepaliveTimeout = "grpc-keepalive-timeout"
+	// flagGrpcMaxRecvMsgSize is the max allowed size of a message received from tikv.
+	flagGrpcMaxRecvMsgSize = "grpc-max-recv-msg-size"
 	// flagEnableOpenTracing is whether to enable opentracing
-	flagEnableOpenTracing = "enable-opentracing"
-	flagSkipCheckPath     = "skip-check-path"
+	flagEnableOpenTracing  = "enable-opentracing"
+	flagSkipCheckPath      = "skip-check-path"
+	flagSplitRegionMaxKeys = "split-region-max-keys"
 
 	defaultSwitchInterval       = 5 * time.Minute
 	defaultGRPCKeepaliveTime    = 10 * time.Second
 	defaultGRPCKeepaliveTimeout = 3 * time.Second
+	defaultGRPCMaxRecvMsgSize   = 32 * 1024 * 1024 // 32MB
 	defaultChecksumConcurrency  = 512
+	defaultSplitRegionMaxKeys   = 1024
 
 	flagCipherType    = "crypter.method"
 	flagCipherKey     = "crypter.key"
@@ -105,8 +111,11 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 		"the interval of pinging gRPC peer, must keep the same value with TiKV and PD")
 	flags.Duration(flagGrpcKeepaliveTimeout, defaultGRPCKeepaliveTimeout,
 		"the max time a gRPC connection can keep idle before killed, must keep the same value with TiKV and PD")
+	flags.Uint(flagGrpcMaxRecvMsgSize, defaultGRPCMaxRecvMsgSize,
+		"the max allowed size of a message received from TiKV")
 	_ = flags.MarkHidden(flagGrpcKeepaliveTime)
 	_ = flags.MarkHidden(flagGrpcKeepaliveTimeout)
+	_ = flags.MarkHidden(flagGrpcMaxRecvMsgSize)
 
 	flags.Bool(flagEnableOpenTracing, false,
 		"Set whether to enable opentracing during the backup/restore process")
@@ -115,6 +124,9 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 	_ = flags.MarkHidden(flagNoCreds)
 	flags.BoolP(flagSkipCheckPath, "", false, "Skip path verification")
 	_ = flags.MarkHidden(flagSkipCheckPath)
+	flags.Uint(flagSplitRegionMaxKeys, defaultSplitRegionMaxKeys,
+		"The max number of keys in a single split region request")
+	_ = flags.MarkHidden(flagSplitRegionMaxKeys)
 
 	flags.String(flagCipherType, "plaintext", "Encrypt/decrypt method, "+
 		"be one of plaintext|aes128-ctr|aes192-ctr|aes256-ctr case-insensitively, "+
@@ -330,6 +342,14 @@ func GetKeepalive(cfg *Config) keepalive.ClientParameters {
 	return keepalive.ClientParameters{
 		Time:    cfg.GRPCKeepaliveTime,
 		Timeout: cfg.GRPCKeepaliveTimeout,
+	}
+}
+
+// GetSpliterConfig get the spliter config.
+func GetSpliterConfig(cfg *Config) restore.SpliterConfig {
+	return restore.SpliterConfig{
+		GRPCMaxRecvMsgSize: int(cfg.GRPCMaxRecvMsgSize),
+		SplitRegionMaxKeys: int(cfg.SplitRegionMaxKeys),
 	}
 }
 

--- a/br/pkg/task/config.go
+++ b/br/pkg/task/config.go
@@ -64,6 +64,11 @@ type Config struct {
 	GRPCKeepaliveTime time.Duration `json:"grpc-keepalive-time" toml:"grpc-keepalive-time"`
 	// GrpcKeepaliveTimeout is the max time a grpc conn can keep idel before killed.
 	GRPCKeepaliveTimeout time.Duration `json:"grpc-keepalive-timeout" toml:"grpc-keepalive-timeout"`
+	// GRPCMaxRecvMsgSize is the max allowed size of a message received from tikv.
+	GRPCMaxRecvMsgSize uint `json:"grpc-max-recv-msg-size" toml:"grpc-max-recv-msg-size"`
+
+	// SplitRegionMaxKeys is the max number of keys in a single split region request.
+	SplitRegionMaxKeys uint `json:"split-region-max-keys" toml:"split-region-max-keys"`
 
 	CipherInfo backuppb.CipherInfo `json:"-" toml:"-"`
 }
@@ -165,7 +170,15 @@ func (cfg *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	cfg.GRPCMaxRecvMsgSize, err = flags.GetUint(flagGrpcMaxRecvMsgSize)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	cfg.EnableOpenTracing, err = flags.GetBool(flagEnableOpenTracing)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	cfg.SplitRegionMaxKeys, err = flags.GetUint(flagSplitRegionMaxKeys)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -212,5 +225,12 @@ func (cfg *Config) adjust() {
 	}
 	if cfg.ChecksumConcurrency == 0 {
 		cfg.ChecksumConcurrency = defaultChecksumConcurrency
+	}
+	if cfg.GRPCMaxRecvMsgSize == 0 {
+		cfg.GRPCMaxRecvMsgSize = defaultGRPCMaxRecvMsgSize
+	}
+
+	if cfg.SplitRegionMaxKeys == 0 {
+		cfg.SplitRegionMaxKeys = defaultSplitRegionMaxKeys
 	}
 }

--- a/br/tests/rawkv/tikv_br.go
+++ b/br/tests/rawkv/tikv_br.go
@@ -27,6 +27,16 @@ func (b *TiKVBrRunCmd) Pd(pd string) *TiKVBrRunCmd {
 	return b
 }
 
+func (b *TiKVBrRunCmd) SplitRegionMaxKeys(maxKeys uint) *TiKVBrRunCmd {
+	b.options = append(b.options, fmt.Sprintf("--split-region-max-keys=%d", maxKeys))
+	return b
+}
+
+func (b *TiKVBrRunCmd) GRPCMaxRecvMsgSize(size uint) *TiKVBrRunCmd {
+	b.options = append(b.options, fmt.Sprintf("--grpc-max-recv-msg-size=%d", size))
+	return b
+}
+
 func (b *TiKVBrRunCmd) Storage(storage string, isLocal bool) *TiKVBrRunCmd {
 	b.options = append(b.options, fmt.Sprintf("--storage=%s", storage))
 	b.local = isLocal


### PR DESCRIPTION
<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #421

Problem Description: **br: split regions failed**

### What is changed and how does it work?

- Separate keys to smaller batch with maximum number of keys of `1024`.
- Add flags to specify split region max keys and allowed gRPC message size.
- Use `split-region-max-keys = 4` for integration tests.
- Adjust region split threshold to cover condition of more regions in integration tests.

### Code changes

<!-- REMOVE the items that are not applicable -->

- No.

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Integration test

Manually confirm the coverage of split region with max keys = `4` by logs of integration tests.

```
[2025/04/16 10:06:03.597 +08:00] [INFO] [split.go:134] ["get split keys for region"] [len=24] [region=354]
[2025/04/16 10:06:03.597 +08:00] [INFO] [split.go:157] ["split regions"] [region="{ID=354,startKey=endKey=72000000696E6465FF783A5F3030303030FF3030303030303036FF3430333237330000FD,epoch=\"conf_ver:1 version:126 \",peers=\"id:355 store_id:1 \"}"] [keys="{total=4,keys=\"[72000000696E6465783A5F30303030303030303030303032353436363638,72000000696E6465783A5F30303030303030303030303032373434393630,72000000696E6465783A5F30303030303030303030303032383939313632,72000000696E6465783A5F30303030303030303030303033303433353134]\"}"] [ranges="{total=31,ranges=\"[\\\"[72000000696E6465783A5F30303030303030303030303032353030303030, 72000000696E6465783A5F30303030303030303030303032353436363638)\\\",\\\"(skip 29)\\\",\\\"[72000000696E6465783A5F30303030303030303030303037333832383332, 72000000696E6465783A5F30303030303030303030303037353030303030)\\\"]\",totalFiles=31,totalKVs=5000000,totalBytes=260000000,totalSize=260000000}"]
[2025/04/16 10:06:03.741 +08:00] [INFO] [split.go:186] ["scattered regions"] [count=4]
[2025/04/16 10:06:03.742 +08:00] [INFO] [split.go:157] ["split regions"] [region="{ID=354,startKey=72000000696E6465FF783A5F3030303030FF3030303030303033FF3034333531340000FD,endKey=72000000696E6465FF783A5F3030303030FF3030303030303036FF3430333237330000FD,epoch=\"conf_ver:1 version:130 \",peers=\"id:355 store_id:1 \"}"] [keys="{total=4,keys=\"[72000000696E6465783A5F30303030303030303030303033323431343637,72000000696E6465783A5F30303030303030303030303033343137303839,72000000696E6465783A5F30303030303030303030303033353235313431,72000000696E6465783A5F30303030303030303030303033363935333836]\"}"] [ranges="{total=31,ranges=\"[\\\"[72000000696E6465783A5F30303030303030303030303032353030303030, 72000000696E6465783A5F30303030303030303030303032353436363638)\\\",\\\"(skip 29)\\\",\\\"[72000000696E6465783A5F30303030303030303030303037333832383332, 72000000696E6465783A5F30303030303030303030303037353030303030)\\\"]\",totalFiles=31,totalKVs=5000000,totalBytes=260000000,totalSize=260000000}"]
[2025/04/16 10:06:03.835 +08:00] [INFO] [split.go:186] ["scattered regions"] [count=4]
[2025/04/16 10:06:03.835 +08:00] [INFO] [split.go:157] ["split regions"] [region="{ID=354,startKey=72000000696E6465FF783A5F3030303030FF3030303030303033FF3639353338360000FD,endKey=72000000696E6465FF783A5F3030303030FF3030303030303036FF3430333237330000FD,epoch=\"conf_ver:1 version:134 \",peers=\"id:355 store_id:1 \"}"] [keys="{total=4,keys=\"[72000000696E6465783A5F30303030303030303030303033383836383534,72000000696E6465783A5F30303030303030303030303034303434383030,72000000696E6465783A5F30303030303030303030303034323037313136,72000000696E6465783A5F30303030303030303030303034333631333138]\"}"] [ranges="{total=31,ranges=\"[\\\"[72000000696E6465783A5F30303030303030303030303032353030303030, 72000000696E6465783A5F30303030303030303030303032353436363638)\\\",\\\"(skip 29)\\\",\\\"[72000000696E6465783A5F30303030303030303030303037333832383332, 72000000696E6465783A5F30303030303030303030303037353030303030)\\\"]\",totalFiles=31,totalKVs=5000000,totalBytes=260000000,totalSize=260000000}"]
[2025/04/16 10:06:03.935 +08:00] [INFO] [split.go:186] ["scattered regions"] [count=4]
[2025/04/16 10:06:03.935 +08:00] [INFO] [split.go:157] ["split regions"] [region="{ID=354,startKey=72000000696E6465FF783A5F3030303030FF3030303030303034FF3336313331380000FD,endKey=72000000696E6465FF783A5F3030303030FF3030303030303036FF3430333237330000FD,epoch=\"conf_ver:1 version:138 \",peers=\"id:355 store_id:1 \"}"] [keys="{total=4,keys=\"[72000000696E6465783A5F30303030303030303030303034353135353230,72000000696E6465783A5F30303030303030303030303034363635333032,72000000696E6465783A5F30303030303030303030303034383438393736,72000000696E6465783A5F30303030303030303030303034393733373036]\"}"] [ranges="{total=31,ranges=\"[\\\"[72000000696E6465783A5F30303030303030303030303032353030303030, 72000000696E6465783A5F30303030303030303030303032353436363638)\\\",\\\"(skip 29)\\\",\\\"[72000000696E6465783A5F30303030303030303030303037333832383332, 72000000696E6465783A5F30303030303030303030303037353030303030)\\\"]\",totalFiles=31,totalKVs=5000000,totalBytes=260000000,totalSize=260000000}"]
[2025/04/16 10:06:04.058 +08:00] [INFO] [split.go:186] ["scattered regions"] [count=4]
[2025/04/16 10:06:04.059 +08:00] [INFO] [split.go:157] ["split regions"] [region="{ID=354,startKey=72000000696E6465FF783A5F3030303030FF3030303030303034FF3937333730360000FD,endKey=72000000696E6465FF783A5F3030303030FF3030303030303036FF3430333237330000FD,epoch=\"conf_ver:1 version:142 \",peers=\"id:355 store_id:1 \"}"] [keys="{total=4,keys=\"[72000000696E6465783A5F30303030303030303030303035303833323534,72000000696E6465783A5F30303030303030303030303035333033313734,72000000696E6465783A5F30303030303030303030303035343630373834,72000000696E6465783A5F30303030303030303030303035363134393836]\"}"] [ranges="{total=31,ranges=\"[\\\"[72000000696E6465783A5F30303030303030303030303032353030303030, 72000000696E6465783A5F30303030303030303030303032353436363638)\\\",\\\"(skip 29)\\\",\\\"[72000000696E6465783A5F30303030303030303030303037333832383332, 72000000696E6465783A5F30303030303030303030303037353030303030)\\\"]\",totalFiles=31,totalKVs=5000000,totalBytes=260000000,totalSize=260000000}"]
[2025/04/16 10:06:04.137 +08:00] [INFO] [split.go:186] ["scattered regions"] [count=4]
[2025/04/16 10:06:04.137 +08:00] [INFO] [split.go:157] ["split regions"] [region="{ID=354,startKey=72000000696E6465FF783A5F3030303030FF3030303030303035FF3631343938360000FD,endKey=72000000696E6465FF783A5F3030303030FF3030303030303036FF3430333237330000FD,epoch=\"conf_ver:1 version:146 \",peers=\"id:355 store_id:1 \"}"] [keys="{total=4,keys=\"[72000000696E6465783A5F30303030303030303030303035373431313235,72000000696E6465783A5F30303030303030303030303035393130363031,72000000696E6465783A5F30303030303030303030303036303230303231,72000000696E6465783A5F30303030303030303030303036323030363233]\"}"] [ranges="{total=31,ranges=\"[\\\"[72000000696E6465783A5F30303030303030303030303032353030303030, 72000000696E6465783A5F30303030303030303030303032353436363638)\\\",\\\"(skip 29)\\\",\\\"[72000000696E6465783A5F30303030303030303030303037333832383332, 72000000696E6465783A5F30303030303030303030303037353030303030)\\\"]\",totalFiles=31,totalKVs=5000000,totalBytes=260000000,totalSize=260000000}"]
[2025/04/16 10:06:04.232 +08:00] [INFO] [split.go:186] ["scattered regions"] [count=4]
```

### Side effects

<!-- REMOVE the items that are not applicable -->
- No side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- No related changes

### To reviewers

<!-- Please keep the following text as a reminder to PR reviewers -->
Please follow these principles to check this pull requests:

- **Concentration**. One pull request should only do one thing. No matter how small it is, the change does exactly one thing and gets it right. Don't mix other changes into it.
- **Tests**. A pull request should be test covered, whether the tests are unit tests, integration tests, or end-to-end tests. Tests should be sufficient, correct and don't slow down the CI pipeline largely.
- **Functionality**. The pull request should implement what the author intends to do and fit well in the existing code base, resolve a real problem for TiDB/TiKV users. To get the author's intention and the pull request design, you could follow the discussions in the corresponding GitHub issue or [internal.tidb.io](https://internals.tidb.io) topic.
- **Style**. Code in the pull request should follow common programming style. *(For Go, we have style checkers in CI)*. However, sometimes the existing code is inconsistent with the style guide, you should maintain consistency with the existing code or file a new issue to fix the existing code style first.
- **Documentation**. If a pull request changes how users build, test, interact with, or release code, you must check whether it also updates the related documentation such as READMEs and any generated reference docs. Similarly, if a pull request deletes or deprecates code, you must check whether or not the corresponding documentation should also be deleted.
- **Performance**. If you find the pull request may affect performance, you could ask the author to provide a benchmark result.

*(The above text mainly refers to [TiDB Development Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/review-a-pr.html#checking-pull-requests). It's also highly recommended to read about [Writing code review comments](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/review-a-pr.html#writing-code-review-comments))*
