### PR TITLE
[close #421] [br-release-1.0] br: Split for smaller batch of keys (#422)

### DIFF
--- a/.github/config/br_pd.toml
+++ b/.github/config/br_pd.toml
@@ -2,3 +2,8 @@
 [replication]
 enable-placement-rules = true
 max-replicas = 1
+
+[schedule]
+max-merge-region-size = 2
+max-merge-region-keys = 40000
+split-merge-interval = "10s"

--- a/.github/config/br_rawkv.toml
+++ b/.github/config/br_rawkv.toml
@@ -7,6 +7,12 @@ pd-heartbeat-tick-interval = "2s"
 pd-store-heartbeat-tick-interval = "5s"
 split-region-check-tick-interval = "1s"
 
+# 10000000 keys & ~480MB data size in integration tests
+[coprocessor]
+region-split-size = "10MiB"
+region-split-keys = 200000
+batch-split-limit = 100
+
 [rocksdb]
 max-open-files = 10000
 
@@ -14,4 +20,5 @@ max-open-files = 10000
 max-open-files = 10000
 
 [storage]
+reserve-space = "0MiB"
 enable-ttl = true

--- a/.github/workflows/ci-br.yml
+++ b/.github/workflows/ci-br.yml
@@ -1,10 +1,14 @@
 name: TiKV-BR
 on:
   push:
-    branches: main
+    branches:
+      - main
+      - br-release-*
     paths: br/**
   pull_request:
-    branches: main
+    branches:
+      - main
+      - br-release-*
     paths: br/**
 
 permissions:

--- a/.github/workflows/ci-br.yml
+++ b/.github/workflows/ci-br.yml
@@ -80,8 +80,6 @@ jobs:
       - name: start tikv cluster
         run: |
           # start tikv
-          # Output the api version
-          echo "API_VERSION=${{ matrix.api_version }}" >> $GITHUB_ENV
           echo -e "\napi-version = ${{ matrix.api_version }}\n" >> /home/runner/work/migration/migration/.github/config/br_rawkv.toml
           /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/migration/migration/.github/config/br_rawkv.toml --pd.port 2379 --pd.config /home/runner/work/migration/migration/.github/config/br_pd.toml &> raw.out 2>&1 &
           # The first run of `tiup` has to download all components so it'll take longer.
@@ -91,6 +89,8 @@ jobs:
             exit 1
           fi
           echo "PD_ADDR=127.0.0.1:2379" >> $GITHUB_ENV
+          # Output the api version
+          echo "API_VERSION=${{ matrix.api_version }}" >> $GITHUB_ENV
           # Log the output
           echo "$(cat raw.out)" >&2
       - name: run integration test

--- a/.github/workflows/ci-br.yml
+++ b/.github/workflows/ci-br.yml
@@ -80,6 +80,8 @@ jobs:
       - name: start tikv cluster
         run: |
           # start tikv
+          # Output the api version
+          echo "API_VERSION=${{ matrix.api_version }}" >> $GITHUB_ENV
           echo -e "\napi-version = ${{ matrix.api_version }}\n" >> /home/runner/work/migration/migration/.github/config/br_rawkv.toml
           /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/migration/migration/.github/config/br_rawkv.toml --pd.port 2379 --pd.config /home/runner/work/migration/migration/.github/config/br_pd.toml &> raw.out 2>&1 &
           # The first run of `tiup` has to download all components so it'll take longer.

--- a/.github/workflows/ci-br.yml
+++ b/.github/workflows/ci-br.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tikv_version: [nightly]
+        tikv_version: [v6.5.3]
         api_version: [1, 2]
     steps:
       - uses: actions/checkout@v2
@@ -81,13 +81,14 @@ jobs:
         run: |
           # start tikv
           echo -e "\napi-version = ${{ matrix.api_version }}\n" >> /home/runner/work/migration/migration/.github/config/br_rawkv.toml
-          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/migration/migration/.github/config/br_rawkv.toml --pd.config /home/runner/work/migration/migration/.github/config/br_pd.toml &> raw.out 2>&1 &
+          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/migration/migration/.github/config/br_rawkv.toml --pd.port 2379 --pd.config /home/runner/work/migration/migration/.github/config/br_pd.toml &> raw.out 2>&1 &
           # The first run of `tiup` has to download all components so it'll take longer.
-          sleep 1m 30s
-          # Parse PD address from `tiup` output
-          echo "PD_ADDR=$(cat raw.out | grep -oP '(?<=PD client endpoints: \[)[0-9\.:]+(?=\])')" >> $GITHUB_ENV
-          # Output the api version
-          echo "API_VERSION=${{ matrix.api_version }}" >> $GITHUB_ENV
+          timeout 180 tail -f raw.out | grep -q 'PD Endpoints'
+          if [ $? -ne 0 ]; then
+            echo "Failed to start TiKV cluster"
+            exit 1
+          fi
+          echo "PD_ADDR=127.0.0.1:2379" >> $GITHUB_ENV
           # Log the output
           echo "$(cat raw.out)" >&2
       - name: run integration test

--- a/br/Makefile
+++ b/br/Makefile
@@ -22,13 +22,14 @@ PACKAGES    := go list ./...
 DIRECTORIES := $(PACKAGES) | sed 's|github.com/tikv/migration/br/||'
 
 # build & test
-BR_BIN_PATH    ?= bin/tikv-br
-TEST_BIN_PATH  ?= bin/tikv-br.test
-COVERAGE_DIR   ?= build
-TEST_PARALLEL  ?= 8
-PD_ADDR        ?= 127.0.0.1:2379
-BR_LOCAL_STORE ?= /tmp/backup_restore_test
-API_VERSION    ?= 1
+BR_BIN_PATH           ?= bin/tikv-br
+TEST_BIN_PATH         ?= bin/tikv-br.test
+COVERAGE_DIR          ?= build
+TEST_PARALLEL         ?= 8
+PD_ADDR               ?= 127.0.0.1:2379
+SPLIT_REGION_MAX_KEYS ?= 4
+BR_LOCAL_STORE        ?= /tmp/backup_restore_test
+API_VERSION           ?= 1
 
 LDFLAGS += -X "github.com/tikv/migration/br/pkg/version/build.ReleaseVersion=$(shell git describe --tags --dirty --always)"
 LDFLAGS += -X "github.com/tikv/migration/br/pkg/version/build.BuildTS=$(shell date -u '+%Y-%m-%d %H:%M:%S')"
@@ -61,6 +62,7 @@ test: tools/bin/gocov tools/bin/gocov-xml
 test/integration: build/br-test build/rawkv-integration-test
 	./bin/rawkv_test --pd=${PD_ADDR} \
 		--br='${TEST_BIN_PATH}' \
+		--split-region-max-keys=${SPLIT_REGION_MAX_KEYS} \
 		--br-storage=${BR_LOCAL_STORE} \
 		--api-version=${API_VERSION}
 

--- a/br/pkg/restore/split.go
+++ b/br/pkg/restore/split.go
@@ -53,15 +53,23 @@ var (
 	ScanRegionAttemptTimes = 30
 )
 
+// SpliterConfig is the config for region split.
+type SpliterConfig struct {
+	GRPCMaxRecvMsgSize int
+	SplitRegionMaxKeys int
+}
+
 // RegionSplitter is a executor of region split by rules.
 type RegionSplitter struct {
 	client SplitClient
+	conf   SpliterConfig
 }
 
 // NewRegionSplitter returns a new RegionSplitter.
-func NewRegionSplitter(client SplitClient) *RegionSplitter {
+func NewRegionSplitter(client SplitClient, conf SpliterConfig) *RegionSplitter {
 	return &RegionSplitter{
 		client: client,
+		conf:   conf,
 	}
 }
 
@@ -122,46 +130,68 @@ SplitRegions:
 		for _, region := range regions {
 			regionMap[region.Region.GetId()] = region
 		}
-		for regionID, keys := range splitKeyMap {
-			log.Info("get split keys for region", zap.Int("len", len(keys)), zap.Uint64("region", regionID))
-			var newRegions []*RegionInfo
-			region := regionMap[regionID]
-			log.Info("split regions",
-				logutil.Region(region.Region), logutil.Keys(keys), rtree.ZapRanges(ranges))
-			newRegions, errSplit = rs.splitAndScatterRegions(ctx, region, keys)
-			if errSplit != nil {
-				if strings.Contains(errSplit.Error(), "no valid key") {
-					for _, key := range keys {
-						// Region start/end keys are encoded. split_region RPC
-						// requires raw keys (without encoding).
-						log.Error("split regions no valid key",
-							logutil.Key("startKey", region.Region.StartKey),
-							logutil.Key("endKey", region.Region.EndKey),
-							logutil.Key("key", codec.EncodeBytes(nil, key)),
-							rtree.ZapRanges(ranges))
+		for regionID, regionKeys := range splitKeyMap {
+			log.Info("get split keys for region", zap.Int("len", len(regionKeys)), zap.Uint64("region", regionID))
+
+			for i := 0; i < len(regionKeys); i += rs.conf.SplitRegionMaxKeys {
+				end := i + rs.conf.SplitRegionMaxKeys
+				if end > len(regionKeys) {
+					end = len(regionKeys)
+				}
+				keys := regionKeys[i:end]
+
+				var region *RegionInfo
+				if i == 0 {
+					region = regionMap[regionID]
+				} else {
+					encodedKey := codec.EncodeBytes(nil, keys[0])
+					var errGetRegion error
+					region, errGetRegion = rs.client.GetRegion(ctx, encodedKey)
+					if errGetRegion != nil {
+						time.Sleep(interval)
+						log.Warn("get region failed, retry", logutil.Key("encodedKey", encodedKey), zap.Error(errGetRegion))
+						continue SplitRegions
 					}
-					return errors.Trace(errSplit)
 				}
-				interval = 2 * interval
-				if interval > SplitMaxRetryInterval {
-					interval = SplitMaxRetryInterval
+
+				log.Info("split regions",
+					logutil.Region(region.Region), logutil.Keys(keys), rtree.ZapRanges(ranges))
+				var newRegions []*RegionInfo
+				newRegions, errSplit = rs.splitAndScatterRegions(ctx, region, keys)
+				if errSplit != nil {
+					if strings.Contains(errSplit.Error(), "no valid key") {
+						for _, key := range keys {
+							// Region start/end keys are encoded. split_region RPC
+							// requires raw keys (without encoding).
+							log.Error("split regions no valid key",
+								logutil.Key("startKey", region.Region.StartKey),
+								logutil.Key("endKey", region.Region.EndKey),
+								logutil.Key("key", codec.EncodeBytes(nil, key)),
+								rtree.ZapRanges(ranges))
+						}
+						return errors.Trace(errSplit)
+					}
+					interval = 2 * interval
+					if interval > SplitMaxRetryInterval {
+						interval = SplitMaxRetryInterval
+					}
+					time.Sleep(interval)
+					log.Warn("split regions failed, retry",
+						zap.Error(errSplit),
+						logutil.Region(region.Region),
+						logutil.Leader(region.Leader),
+						logutil.Keys(keys), rtree.ZapRanges(ranges))
+					continue SplitRegions
 				}
-				time.Sleep(interval)
-				log.Warn("split regions failed, retry",
-					zap.Error(errSplit),
-					logutil.Region(region.Region),
-					logutil.Leader(region.Leader),
-					logutil.Keys(keys), rtree.ZapRanges(ranges))
-				continue SplitRegions
+				log.Info("scattered regions", zap.Int("count", len(newRegions)))
+				if len(newRegions) != len(keys) {
+					log.Warn("split key count and new region count mismatch",
+						zap.Int("new region count", len(newRegions)),
+						zap.Int("split key count", len(keys)))
+				}
+				scatterRegions = append(scatterRegions, newRegions...)
+				onSplit(keys)
 			}
-			log.Info("scattered regions", zap.Int("count", len(newRegions)))
-			if len(newRegions) != len(keys) {
-				log.Warn("split key count and new region count mismatch",
-					zap.Int("new region count", len(newRegions)),
-					zap.Int("split key count", len(keys)))
-			}
-			scatterRegions = append(scatterRegions, newRegions...)
-			onSplit(keys)
 		}
 		break
 	}

--- a/br/pkg/restore/split_test.go
+++ b/br/pkg/restore/split_test.go
@@ -276,7 +276,7 @@ func ScatterFinishInTimeImpl(t *testing.T, needEncodeKey bool) {
 	client := initTestClient()
 	ranges := initRanges()
 	rewriteRules := initRewriteRules()
-	regionSplitter := restore.NewRegionSplitter(client)
+	regionSplitter := restore.NewRegionSplitter(client, defaultSpliterCfg)
 
 	ctx := context.Background()
 	err := regionSplitter.Split(ctx, ranges, rewriteRules, needEncodeKey, func(key [][]byte) {}) // TODO: add test case for "isRawKV=true"
@@ -335,7 +335,7 @@ func TestSplitAndScatter(t *testing.T) {
 func runTestSplitAndScatterWith(t *testing.T, client *TestClient, needEncodeKey bool) {
 	ranges := initRanges()
 	rewriteRules := initRewriteRules()
-	regionSplitter := restore.NewRegionSplitter(client)
+	regionSplitter := restore.NewRegionSplitter(client, defaultSpliterCfg)
 
 	ctx := context.Background()
 	err := regionSplitter.Split(ctx, ranges, rewriteRules, needEncodeKey, func(key [][]byte) {}) // TODO: add test case for "isRawKV=true"

--- a/br/pkg/restore/split_test.go
+++ b/br/pkg/restore/split_test.go
@@ -24,6 +24,11 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+var defaultSpliterCfg = restore.SpliterConfig{
+	GRPCMaxRecvMsgSize: 1024 * 1024,
+	SplitRegionMaxKeys: 16,
+}
+
 type TestClient struct {
 	mu                  sync.RWMutex
 	stores              map[uint64]*metapb.Store

--- a/br/pkg/restore/util.go
+++ b/br/pkg/restore/util.go
@@ -110,13 +110,14 @@ func matchOldPrefix(key []byte, rewriteRules *RewriteRules) *import_sstpb.Rewrit
 func SplitRanges(
 	ctx context.Context,
 	client *Client,
+	spliterConf SpliterConfig,
 	ranges []rtree.Range,
 	rewriteRules *RewriteRules,
 	updateCh glue.Progress,
 	isRawKv bool,
 	needEncodeKey bool,
 ) error {
-	splitter := NewRegionSplitter(NewSplitClient(client.GetPDClient(), client.GetTLSConfig(), isRawKv))
+	splitter := NewRegionSplitter(NewSplitClient(client.GetPDClient(), client.GetTLSConfig(), spliterConf, isRawKv), spliterConf)
 
 	return splitter.Split(ctx, ranges, rewriteRules, needEncodeKey, func(keys [][]byte) {
 		updateCh.Inc()

--- a/br/pkg/task/config.go
+++ b/br/pkg/task/config.go
@@ -63,6 +63,11 @@ type Config struct {
 	GRPCKeepaliveTime time.Duration `json:"grpc-keepalive-time" toml:"grpc-keepalive-time"`
 	// GrpcKeepaliveTimeout is the max time a grpc conn can keep idel before killed.
 	GRPCKeepaliveTimeout time.Duration `json:"grpc-keepalive-timeout" toml:"grpc-keepalive-timeout"`
+	// GRPCMaxRecvMsgSize is the max allowed size of a message received from tikv.
+	GRPCMaxRecvMsgSize uint `json:"grpc-max-recv-msg-size" toml:"grpc-max-recv-msg-size"`
+
+	// SplitRegionMaxKeys is the max number of keys in a single split region request.
+	SplitRegionMaxKeys uint `json:"split-region-max-keys" toml:"split-region-max-keys"`
 
 	CipherInfo backuppb.CipherInfo `json:"-" toml:"-"`
 }
@@ -164,7 +169,15 @@ func (cfg *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	cfg.GRPCMaxRecvMsgSize, err = flags.GetUint(flagGrpcMaxRecvMsgSize)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	cfg.EnableOpenTracing, err = flags.GetBool(flagEnableOpenTracing)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	cfg.SplitRegionMaxKeys, err = flags.GetUint(flagSplitRegionMaxKeys)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -211,5 +224,12 @@ func (cfg *Config) adjust() {
 	}
 	if cfg.ChecksumConcurrency == 0 {
 		cfg.ChecksumConcurrency = defaultChecksumConcurrency
+	}
+	if cfg.GRPCMaxRecvMsgSize == 0 {
+		cfg.GRPCMaxRecvMsgSize = defaultGRPCMaxRecvMsgSize
+	}
+
+	if cfg.SplitRegionMaxKeys == 0 {
+		cfg.SplitRegionMaxKeys = defaultSplitRegionMaxKeys
 	}
 }

--- a/br/tests/rawkv/tikv_br.go
+++ b/br/tests/rawkv/tikv_br.go
@@ -27,6 +27,16 @@ func (b *TiKVBrRunCmd) Pd(pd string) *TiKVBrRunCmd {
 	return b
 }
 
+func (b *TiKVBrRunCmd) SplitRegionMaxKeys(maxKeys uint) *TiKVBrRunCmd {
+	b.options = append(b.options, fmt.Sprintf("--split-region-max-keys=%d", maxKeys))
+	return b
+}
+
+func (b *TiKVBrRunCmd) GRPCMaxRecvMsgSize(size uint) *TiKVBrRunCmd {
+	b.options = append(b.options, fmt.Sprintf("--grpc-max-recv-msg-size=%d", size))
+	return b
+}
+
 func (b *TiKVBrRunCmd) Storage(storage string, isLocal bool) *TiKVBrRunCmd {
 	b.options = append(b.options, fmt.Sprintf("--storage=%s", storage))
 	b.local = isLocal


### PR DESCRIPTION
Cherry pick of #422

<!-- Thank you for contributing to TiKV Migration Toolset!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #421

Problem Description: **br: split regions failed**

### What is changed and how does it work?

- Separate keys to smaller batch with maximum number of keys of `1024`.
- Add flags to specify split region max keys and allowed gRPC message size.
- Use `split-region-max-keys = 4` for integration tests.
- Adjust region split threshold to cover condition of more regions in integration tests.

### Code changes

<!-- REMOVE the items that are not applicable -->

- No.

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Integration test

Manually confirm the coverage of split region with max keys = `4` by logs of integration tests.

```
[2025/04/16 10:06:03.597 +08:00] [INFO] [split.go:134] ["get split keys for region"] [len=24] [region=354]
[2025/04/16 10:06:03.597 +08:00] [INFO] [split.go:157] ["split regions"] [region="{ID=354,startKey=endKey=72000000696E6465FF783A5F3030303030FF3030303030303036FF3430333237330000FD,epoch=\"conf_ver:1 version:126 \",peers=\"id:355 store_id:1 \"}"] [keys="{total=4,keys=\"[72000000696E6465783A5F30303030303030303030303032353436363638,72000000696E6465783A5F30303030303030303030303032373434393630,72000000696E6465783A5F30303030303030303030303032383939313632,72000000696E6465783A5F30303030303030303030303033303433353134]\"}"] [ranges="{total=31,ranges=\"[\\\"[72000000696E6465783A5F30303030303030303030303032353030303030, 72000000696E6465783A5F30303030303030303030303032353436363638)\\\",\\\"(skip 29)\\\",\\\"[72000000696E6465783A5F30303030303030303030303037333832383332, 72000000696E6465783A5F30303030303030303030303037353030303030)\\\"]\",totalFiles=31,totalKVs=5000000,totalBytes=260000000,totalSize=260000000}"]
[2025/04/16 10:06:03.741 +08:00] [INFO] [split.go:186] ["scattered regions"] [count=4]
[2025/04/16 10:06:03.742 +08:00] [INFO] [split.go:157] ["split regions"] [region="{ID=354,startKey=72000000696E6465FF783A5F3030303030FF3030303030303033FF3034333531340000FD,endKey=72000000696E6465FF783A5F3030303030FF3030303030303036FF3430333237330000FD,epoch=\"conf_ver:1 version:130 \",peers=\"id:355 store_id:1 \"}"] [keys="{total=4,keys=\"[72000000696E6465783A5F30303030303030303030303033323431343637,72000000696E6465783A5F30303030303030303030303033343137303839,72000000696E6465783A5F30303030303030303030303033353235313431,72000000696E6465783A5F30303030303030303030303033363935333836]\"}"] [ranges="{total=31,ranges=\"[\\\"[72000000696E6465783A5F30303030303030303030303032353030303030, 72000000696E6465783A5F30303030303030303030303032353436363638)\\\",\\\"(skip 29)\\\",\\\"[72000000696E6465783A5F30303030303030303030303037333832383332, 72000000696E6465783A5F30303030303030303030303037353030303030)\\\"]\",totalFiles=31,totalKVs=5000000,totalBytes=260000000,totalSize=260000000}"]
[2025/04/16 10:06:03.835 +08:00] [INFO] [split.go:186] ["scattered regions"] [count=4]
[2025/04/16 10:06:03.835 +08:00] [INFO] [split.go:157] ["split regions"] [region="{ID=354,startKey=72000000696E6465FF783A5F3030303030FF3030303030303033FF3639353338360000FD,endKey=72000000696E6465FF783A5F3030303030FF3030303030303036FF3430333237330000FD,epoch=\"conf_ver:1 version:134 \",peers=\"id:355 store_id:1 \"}"] [keys="{total=4,keys=\"[72000000696E6465783A5F30303030303030303030303033383836383534,72000000696E6465783A5F30303030303030303030303034303434383030,72000000696E6465783A5F30303030303030303030303034323037313136,72000000696E6465783A5F30303030303030303030303034333631333138]\"}"] [ranges="{total=31,ranges=\"[\\\"[72000000696E6465783A5F30303030303030303030303032353030303030, 72000000696E6465783A5F30303030303030303030303032353436363638)\\\",\\\"(skip 29)\\\",\\\"[72000000696E6465783A5F30303030303030303030303037333832383332, 72000000696E6465783A5F30303030303030303030303037353030303030)\\\"]\",totalFiles=31,totalKVs=5000000,totalBytes=260000000,totalSize=260000000}"]
[2025/04/16 10:06:03.935 +08:00] [INFO] [split.go:186] ["scattered regions"] [count=4]
[2025/04/16 10:06:03.935 +08:00] [INFO] [split.go:157] ["split regions"] [region="{ID=354,startKey=72000000696E6465FF783A5F3030303030FF3030303030303034FF3336313331380000FD,endKey=72000000696E6465FF783A5F3030303030FF3030303030303036FF3430333237330000FD,epoch=\"conf_ver:1 version:138 \",peers=\"id:355 store_id:1 \"}"] [keys="{total=4,keys=\"[72000000696E6465783A5F30303030303030303030303034353135353230,72000000696E6465783A5F30303030303030303030303034363635333032,72000000696E6465783A5F30303030303030303030303034383438393736,72000000696E6465783A5F30303030303030303030303034393733373036]\"}"] [ranges="{total=31,ranges=\"[\\\"[72000000696E6465783A5F30303030303030303030303032353030303030, 72000000696E6465783A5F30303030303030303030303032353436363638)\\\",\\\"(skip 29)\\\",\\\"[72000000696E6465783A5F30303030303030303030303037333832383332, 72000000696E6465783A5F30303030303030303030303037353030303030)\\\"]\",totalFiles=31,totalKVs=5000000,totalBytes=260000000,totalSize=260000000}"]
[2025/04/16 10:06:04.058 +08:00] [INFO] [split.go:186] ["scattered regions"] [count=4]
[2025/04/16 10:06:04.059 +08:00] [INFO] [split.go:157] ["split regions"] [region="{ID=354,startKey=72000000696E6465FF783A5F3030303030FF3030303030303034FF3937333730360000FD,endKey=72000000696E6465FF783A5F3030303030FF3030303030303036FF3430333237330000FD,epoch=\"conf_ver:1 version:142 \",peers=\"id:355 store_id:1 \"}"] [keys="{total=4,keys=\"[72000000696E6465783A5F30303030303030303030303035303833323534,72000000696E6465783A5F30303030303030303030303035333033313734,72000000696E6465783A5F30303030303030303030303035343630373834,72000000696E6465783A5F30303030303030303030303035363134393836]\"}"] [ranges="{total=31,ranges=\"[\\\"[72000000696E6465783A5F30303030303030303030303032353030303030, 72000000696E6465783A5F30303030303030303030303032353436363638)\\\",\\\"(skip 29)\\\",\\\"[72000000696E6465783A5F30303030303030303030303037333832383332, 72000000696E6465783A5F30303030303030303030303037353030303030)\\\"]\",totalFiles=31,totalKVs=5000000,totalBytes=260000000,totalSize=260000000}"]
[2025/04/16 10:06:04.137 +08:00] [INFO] [split.go:186] ["scattered regions"] [count=4]
[2025/04/16 10:06:04.137 +08:00] [INFO] [split.go:157] ["split regions"] [region="{ID=354,startKey=72000000696E6465FF783A5F3030303030FF3030303030303035FF3631343938360000FD,endKey=72000000696E6465FF783A5F3030303030FF3030303030303036FF3430333237330000FD,epoch=\"conf_ver:1 version:146 \",peers=\"id:355 store_id:1 \"}"] [keys="{total=4,keys=\"[72000000696E6465783A5F30303030303030303030303035373431313235,72000000696E6465783A5F30303030303030303030303035393130363031,72000000696E6465783A5F30303030303030303030303036303230303231,72000000696E6465783A5F30303030303030303030303036323030363233]\"}"] [ranges="{total=31,ranges=\"[\\\"[72000000696E6465783A5F30303030303030303030303032353030303030, 72000000696E6465783A5F30303030303030303030303032353436363638)\\\",\\\"(skip 29)\\\",\\\"[72000000696E6465783A5F30303030303030303030303037333832383332, 72000000696E6465783A5F30303030303030303030303037353030303030)\\\"]\",totalFiles=31,totalKVs=5000000,totalBytes=260000000,totalSize=260000000}"]
[2025/04/16 10:06:04.232 +08:00] [INFO] [split.go:186] ["scattered regions"] [count=4]
```

### Side effects

<!-- REMOVE the items that are not applicable -->
- No side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- No related changes

### To reviewers

<!-- Please keep the following text as a reminder to PR reviewers -->
Please follow these principles to check this pull requests:

- **Concentration**. One pull request should only do one thing. No matter how small it is, the change does exactly one thing and gets it right. Don't mix other changes into it.
- **Tests**. A pull request should be test covered, whether the tests are unit tests, integration tests, or end-to-end tests. Tests should be sufficient, correct and don't slow down the CI pipeline largely.
- **Functionality**. The pull request should implement what the author intends to do and fit well in the existing code base, resolve a real problem for TiDB/TiKV users. To get the author's intention and the pull request design, you could follow the discussions in the corresponding GitHub issue or [internal.tidb.io](https://internals.tidb.io) topic.
- **Style**. Code in the pull request should follow common programming style. *(For Go, we have style checkers in CI)*. However, sometimes the existing code is inconsistent with the style guide, you should maintain consistency with the existing code or file a new issue to fix the existing code style first.
- **Documentation**. If a pull request changes how users build, test, interact with, or release code, you must check whether it also updates the related documentation such as READMEs and any generated reference docs. Similarly, if a pull request deletes or deprecates code, you must check whether or not the corresponding documentation should also be deleted.
- **Performance**. If you find the pull request may affect performance, you could ask the author to provide a benchmark result.

*(The above text mainly refers to [TiDB Development Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/review-a-pr.html#checking-pull-requests). It's also highly recommended to read about [Writing code review comments](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/review-a-pr.html#writing-code-review-comments))*
